### PR TITLE
feat: add FCAS dispatch target visibility

### DIFF
--- a/app/backend/batterywatch_api/backfill_ledger.py
+++ b/app/backend/batterywatch_api/backfill_ledger.py
@@ -209,7 +209,7 @@ INSERT INTO historical_backfill_events (
 )
 VALUES (
     %s, %s, %s, %s, %s,
-    jsonb_build_object('records_imported', %s)
+    jsonb_build_object('records_imported', %s::bigint)
 )
 """
 
@@ -228,7 +228,7 @@ INSERT INTO historical_backfill_events (
 )
 VALUES (
     %s, %s, %s, %s, %s,
-    jsonb_build_object('error_summary', %s)
+    jsonb_build_object('error_summary', %s::text)
 )
 """
 

--- a/app/backend/batterywatch_api/backfill_service.py
+++ b/app/backend/batterywatch_api/backfill_service.py
@@ -187,6 +187,12 @@ def _summary(
         "nextday_applied_record_count": result.nextday_applied_record_count,
         "nextday_null_count": result.nextday_null_count,
         "nextday_percentage_count": result.nextday_percentage_count,
+        "nextday_fcas_raw_inserted_count": result.nextday_fcas_raw_inserted_count,
+        "nextday_fcas_raw_replayed_count": result.nextday_fcas_raw_replayed_count,
+        "nextday_fcas_effective_candidate_count": result.nextday_fcas_effective_candidate_count,
+        "nextday_fcas_effective_applied_count": result.nextday_fcas_effective_applied_count,
+        "nextday_fcas_effective_replayed_count": result.nextday_fcas_effective_replayed_count,
+        "nextday_fcas_reported_service_count": result.nextday_fcas_reported_service_count,
         "missing_nextday_months": tuple(
             month.isoformat() for month in missing_nextday_months
         ),

--- a/app/backend/batterywatch_api/historical_backfill.py
+++ b/app/backend/batterywatch_api/historical_backfill.py
@@ -77,6 +77,32 @@ class HistoricalBackfillResult:
         return sum(result.percentage_count for result in self.nextday_results)
 
     @property
+    def nextday_fcas_raw_inserted_count(self) -> int:
+        return sum(result.fcas_raw_inserted for result in self.nextday_results)
+
+    @property
+    def nextday_fcas_raw_replayed_count(self) -> int:
+        return sum(result.fcas_raw_replayed for result in self.nextday_results)
+
+    @property
+    def nextday_fcas_effective_candidate_count(self) -> int:
+        return sum(result.fcas_effective_candidates for result in self.nextday_results)
+
+    @property
+    def nextday_fcas_effective_applied_count(self) -> int:
+        return sum(result.fcas_effective_applied for result in self.nextday_results)
+
+    @property
+    def nextday_fcas_effective_replayed_count(self) -> int:
+        return sum(result.fcas_effective_replayed for result in self.nextday_results)
+
+    @property
+    def nextday_fcas_reported_service_count(self) -> int:
+        return sum(
+            result.fcas_reported_service_count for result in self.nextday_results
+        )
+
+    @property
     def replayed_interval_count(self) -> int:
         return sum(result.replayed_interval_count for result in self.scada_results) + sum(
             result.replayed_interval_count for result in self.price_results
@@ -172,7 +198,7 @@ def run_historical_backfill(
                     claim,
                     spec.requested_start,
                     spec.requested_end,
-                    spec.ingestion_version,
+                    ingestion_version=spec.ingestion_version,
                 )
             )
         else:

--- a/app/backend/batterywatch_api/historical_nextday_backfill.py
+++ b/app/backend/batterywatch_api/historical_nextday_backfill.py
@@ -91,6 +91,7 @@ class HistoricalNextDayBackfillResult:
 class _ValidatedDaily:
     member: NextDayDailyMemberRef
     artifact_sha256: str
+    downloaded_at: datetime
     selected_rows: int
 
 
@@ -263,7 +264,7 @@ def run_nextday_soc_backfill_claim(
                 daily.csv_bytes.decode("utf-8-sig", errors="strict"),
                 duids=duids,
                 source_artifact_id=daily.sha256,
-                downloaded_at=downloaded_at,
+                downloaded_at=nested_result.downloaded_at,
                 ingestion_version=ingestion_version,
                 correction_version=int(member.publication_id),
             ))
@@ -273,7 +274,12 @@ def run_nextday_soc_backfill_claim(
                 if start <= observation.interval_start < end
             )
             validated.append(
-                _ValidatedDaily(member, daily.sha256, len(selected))
+                _ValidatedDaily(
+                    member,
+                    daily.sha256,
+                    nested_result.downloaded_at,
+                    len(selected),
+                )
             )
 
         source_rows = 0
@@ -301,7 +307,7 @@ def run_nextday_soc_backfill_claim(
                 daily.csv_bytes.decode("utf-8-sig", errors="strict"),
                 duids=duids,
                 source_artifact_id=daily.sha256,
-                downloaded_at=downloaded_at,
+                downloaded_at=validated_daily.downloaded_at,
                 ingestion_version=ingestion_version,
                 correction_version=int(validated_daily.member.publication_id),
             ))

--- a/app/backend/batterywatch_api/historical_nextday_backfill.py
+++ b/app/backend/batterywatch_api/historical_nextday_backfill.py
@@ -33,6 +33,7 @@ from .nextday_monthly_extraction import (
     read_nextday_daily_artifact,
     validate_nextday_monthly_archive,
 )
+from .nextday_fcas_ingestion import PostgreSQLNextDayFcasIngestor
 from .nextday_soc import parse_nextday_unit_solution_soc
 from .nextday_soc_ingestion import PostgreSQLNextDaySocIngestor
 
@@ -54,6 +55,36 @@ class HistoricalNextDayBackfillResult:
     effective_replayed: int
     source_null_count: int
     percentage_count: int
+    fcas_raw_inserted: int = 0
+    fcas_raw_replayed: int = 0
+    fcas_effective_candidates: int = 0
+    fcas_effective_applied: int = 0
+    fcas_effective_replayed: int = 0
+    fcas_reported_service_count: int = 0
+
+    @property
+    def fcas_inserted_count(self) -> int:
+        return self.fcas_raw_inserted
+
+    @property
+    def fcas_replayed_count(self) -> int:
+        return self.fcas_raw_replayed
+
+    @property
+    def fcas_candidate_count(self) -> int:
+        return self.fcas_effective_candidates
+
+    @property
+    def fcas_applied_count(self) -> int:
+        return self.fcas_effective_applied
+
+    @property
+    def fcas_effective_replayed_count(self) -> int:
+        return self.fcas_effective_replayed
+
+    @property
+    def fcas_reported_count(self) -> int:
+        return self.fcas_reported_service_count
 
 
 @dataclass(frozen=True, slots=True)
@@ -168,6 +199,7 @@ def run_nextday_soc_backfill_claim(
     ] = read_nextday_daily_artifact,
     parse_csv: Callable[..., tuple[Any, ...]] = parse_nextday_unit_solution_soc,
     ingestor_factory: Callable[[Any], Any] = PostgreSQLNextDaySocIngestor,
+    fcas_ingestor_factory: Callable[[Any], Any] = PostgreSQLNextDayFcasIngestor,
 ) -> Any:
     """Validate all selected daily reports before any SOC observation write."""
 
@@ -252,6 +284,13 @@ def run_nextday_soc_backfill_claim(
         effective_replayed = 0
         source_null_count = 0
         percentage_count = 0
+        fcas_raw_inserted = 0
+        fcas_raw_replayed = 0
+        fcas_effective_candidates = 0
+        fcas_effective_applied = 0
+        fcas_effective_replayed = 0
+        fcas_reported_service_count = 0
+        fcas_projection_seen = False
         for validated_daily in validated:
             daily = read_daily(
                 manifest, resource.body, validated_daily.member
@@ -288,6 +327,25 @@ def run_nextday_soc_backfill_claim(
             source_null_count += ingestion.source_null_count
             percentage_count += ingestion.percentage_count
 
+            # Older injected parsers used by callers may still return envelope
+            # objects without the additive FCAS field.  The production parser
+            # always supplies it; retaining this narrow compatibility path does
+            # not let a real FCAS-bearing observation skip its projection.
+            has_fcas = [hasattr(item, "fcas") for item in selected]
+            if any(has_fcas) and not all(has_fcas):
+                raise ValueError("mixed Next Day SOC/FCAS observation shape")
+            if not has_fcas or not has_fcas[0]:
+                continue
+            with _connection_scope(connect, database_url) as connection:
+                fcas_ingestion = fcas_ingestor_factory(connection).ingest(selected)
+            fcas_projection_seen = True
+            fcas_raw_inserted += fcas_ingestion.raw_inserted
+            fcas_raw_replayed += fcas_ingestion.raw_replayed
+            fcas_effective_candidates += fcas_ingestion.effective_candidates
+            fcas_effective_applied += fcas_ingestion.effective_applied
+            fcas_effective_replayed += fcas_ingestion.effective_replayed
+            fcas_reported_service_count += fcas_ingestion.reported_service_count
+
         fully_replayed = (
             outer_result.replayed
             and daily_artifacts_replayed == len(validated)
@@ -295,6 +353,15 @@ def run_nextday_soc_backfill_claim(
             and raw_replayed == source_rows
             and effective_applied == 0
             and effective_replayed == effective_candidates
+            and (
+                not fcas_projection_seen
+                or (
+                    fcas_raw_inserted == 0
+                    and fcas_raw_replayed == source_rows
+                    and fcas_effective_applied == 0
+                    and fcas_effective_replayed == fcas_effective_candidates
+                )
+            )
         )
         completion = BackfillItemCompletion(fully_replayed, source_rows)
         with _connection_scope(connect, database_url) as connection:
@@ -312,6 +379,12 @@ def run_nextday_soc_backfill_claim(
             effective_replayed,
             source_null_count,
             percentage_count,
+            fcas_raw_inserted,
+            fcas_raw_replayed,
+            fcas_effective_candidates,
+            fcas_effective_applied,
+            fcas_effective_replayed,
+            fcas_reported_service_count,
         )
     except Exception as exc:
         _fail_claim(

--- a/app/backend/batterywatch_api/main.py
+++ b/app/backend/batterywatch_api/main.py
@@ -1,10 +1,13 @@
 """Standalone BatteryWatch HTTP API."""
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from math import isfinite
 import os
 from pathlib import Path
+from typing import Any, cast
 
 from fastapi import APIRouter, FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -21,6 +24,14 @@ from .runtime import (
 from .models import (
     Coverage,
     EstimateMetadata,
+    FcasCoverage,
+    FcasLatestFinalizedMetadata,
+    FcasPoint,
+    FcasPublicationState,
+    FcasResponse,
+    FcasServiceName,
+    FcasServicePoint,
+    FcasServiceSummary,
     Generator,
     GeneratorListResponse,
     HealthResponse,
@@ -29,14 +40,16 @@ from .models import (
     SeriesResponse,
     SeriesSummary,
 )
+from .storage import FCAS_CLEARANCE_EPSILON_MW, FCAS_SERVICES
 
 router = APIRouter()
 
 MAX_WINDOW_SECONDS = 30 * 24 * 60 * 60
+NEM_TIMEZONE = timezone(timedelta(hours=10))
 
 
 def _utc(value: datetime, field: str) -> datetime:
-    if value.tzinfo is None:
+    if value.tzinfo is None or value.utcoffset() is None:
         raise HTTPException(status_code=400, detail=f"{field} must include a UTC offset")
     return value.astimezone(timezone.utc)
 
@@ -144,6 +157,341 @@ def _database_bounds(start: str | None, end: str | None) -> tuple[datetime, date
             detail="Requested range exceeds the 30-day limit",
         )
     return requested_start, requested_end
+
+
+def _fcas_bounds(start: str | None, end: str | None) -> tuple[datetime, datetime]:
+    if start is None or end is None:
+        raise HTTPException(
+            status_code=400,
+            detail="FCAS requires explicit start and end",
+        )
+    try:
+        parsed_start = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        parsed_end = datetime.fromisoformat(end.replace("Z", "+00:00"))
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail="start and end must be ISO-8601 timestamps",
+        ) from None
+    requested_start = _utc(parsed_start, "start")
+    requested_end = _utc(parsed_end, "end")
+    if requested_end <= requested_start:
+        raise HTTPException(status_code=400, detail="end must be after start")
+    if (requested_end - requested_start).total_seconds() > MAX_WINDOW_SECONDS:
+        raise HTTPException(
+            status_code=400,
+            detail="Requested range exceeds the 30-day limit",
+        )
+    return requested_start, requested_end
+
+
+def _fcas_services(value: str | None) -> tuple[FcasServiceName, ...]:
+    if value is None:
+        return FCAS_SERVICES
+    parts = value.split(",")
+    if not parts or any(part not in FCAS_SERVICES for part in parts):
+        raise HTTPException(status_code=400, detail="Invalid FCAS service filter")
+    if len(parts) != len(set(parts)):
+        raise HTTPException(status_code=400, detail="Invalid FCAS service filter")
+    requested = set(parts)
+    return tuple(
+        service
+        for service in FCAS_SERVICES
+        if service in requested
+    )
+
+
+def _fcas_number(value: object, field: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float, Decimal)):
+        raise ValueError(f"invalid FCAS {field}")
+    try:
+        normalized = float(cast(Any, value))
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"invalid FCAS {field}") from exc
+    if not isfinite(normalized) or normalized < 0:
+        raise ValueError(f"invalid FCAS {field}")
+    return normalized
+
+
+def _fcas_status(value: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or type(value) is not int or value not in {0, 1, 2, 3, 4}:
+        raise ValueError("invalid FCAS enablement status")
+    return value
+
+
+def _fcas_raw_field(raw: object, field: str) -> object:
+    if isinstance(raw, Mapping):
+        return raw[field]
+    return getattr(raw, field)
+
+
+def _fcas_service_point(raw: object | None) -> FcasServicePoint:
+    if raw is None:
+        target = status = actual = None
+    elif isinstance(raw, Mapping):
+        if set(raw) != {
+            "target_mw",
+            "enablement_status",
+            "actual_availability_mw",
+        }:
+            raise ValueError("invalid FCAS service value")
+        target = _fcas_number(raw["target_mw"], "target_mw")
+        status = _fcas_status(raw["enablement_status"])
+        actual = _fcas_number(
+            raw["actual_availability_mw"],
+            "actual_availability_mw",
+        )
+    else:
+        target = _fcas_number(_fcas_raw_field(raw, "target_mw"), "target_mw")
+        status = _fcas_status(_fcas_raw_field(raw, "enablement_status"))
+        actual = _fcas_number(
+            _fcas_raw_field(raw, "actual_availability_mw"),
+            "actual_availability_mw",
+        )
+    enabled = status in (1, 3)
+    trapped = status == 3
+    stranded = status == 4
+    cleared = target is not None and target > FCAS_CLEARANCE_EPSILON_MW
+    return FcasServicePoint(
+        target_mw=target,
+        enablement_status=status,
+        actual_availability_mw=actual,
+        enabled=enabled,
+        trapped=trapped,
+        stranded=stranded,
+        cleared=cleared,
+        participating=cleared and enabled,
+        response_verified=False,
+    )
+
+
+def _fcas_rows_in_window(
+    rows: object,
+    generator: str,
+    start: datetime,
+    end: datetime,
+) -> list[object]:
+    if isinstance(rows, (str, bytes)):
+        raise ValueError("invalid FCAS rows")
+    try:
+        materialized = list(rows)  # type: ignore[arg-type]
+    except TypeError as exc:
+        raise ValueError("invalid FCAS rows") from exc
+    selected = []
+    for row in materialized:
+        if getattr(row, "generator_id") != generator:
+            raise ValueError("FCAS row generator does not match request")
+        interval_start = getattr(row, "interval_start")
+        if start <= interval_start < end:
+            selected.append(row)
+    timestamps = [getattr(row, "interval_start") for row in selected]
+    if len(timestamps) != len(set(timestamps)):
+        raise ValueError("duplicate FCAS interval rows")
+    return sorted(selected, key=lambda row: getattr(row, "interval_start"))
+
+
+def _fcas_projected_points(
+    rows: list[object],
+    selected_services: tuple[FcasServiceName, ...],
+    requested_start: datetime,
+    requested_end: datetime,
+) -> tuple[
+    list[FcasPoint],
+    dict[datetime, dict[FcasServiceName, FcasServicePoint]],
+]:
+    projected: dict[datetime, dict[FcasServiceName, FcasServicePoint]] = {}
+    for row in rows:
+        service_values = getattr(row, "services")
+        if not isinstance(service_values, Mapping) or set(service_values) != set(FCAS_SERVICES):
+            raise ValueError("invalid FCAS service map")
+        all_values: dict[str, FcasServicePoint] = {}
+        for service in FCAS_SERVICES:
+            raw_value = _fcas_raw_field(service_values, service)
+            if raw_value is None:
+                raise ValueError("invalid FCAS service value")
+            all_values[service] = _fcas_service_point(raw_value)
+        projected[getattr(row, "interval_start")] = {
+            service: all_values[service]
+            for service in selected_services
+        }
+
+    points: list[FcasPoint] = []
+    timestamp = _first_aligned_timestamp(requested_start)
+    while timestamp < requested_end:
+        values = projected.get(timestamp, {})
+        points.append(
+            FcasPoint(
+                timestamp=timestamp,
+                services={
+                    service: values.get(service) or _fcas_service_point(None)
+                    for service in selected_services
+                },
+            )
+        )
+        timestamp += INTERVAL
+    return points, projected
+
+
+def _fcas_service_summaries(
+    projected: Mapping[datetime, Mapping[FcasServiceName, FcasServicePoint]],
+    selected_services: tuple[FcasServiceName, ...],
+) -> dict[FcasServiceName, FcasServiceSummary]:
+    summaries: dict[FcasServiceName, FcasServiceSummary] = {}
+    for service in selected_services:
+        values = [point[service] for point in projected.values()]
+        targets = [point.target_mw for point in values if point.target_mw is not None]
+        actual_availability = [
+            point.actual_availability_mw
+            for point in values
+            if point.actual_availability_mw is not None
+        ]
+        summaries[service] = FcasServiceSummary(
+            reported_intervals=sum(
+                point.target_mw is not None
+                or point.enablement_status is not None
+                or point.actual_availability_mw is not None
+                for point in values
+            ),
+            enabled_intervals=sum(point.enabled for point in values),
+            cleared_intervals=sum(point.cleared for point in values),
+            participating_intervals=sum(point.participating for point in values),
+            trapped_intervals=sum(point.trapped for point in values),
+            stranded_intervals=sum(point.stranded for point in values),
+            max_target_mw=max(targets) if targets else None,
+            max_actual_availability_mw=(
+                max(actual_availability) if actual_availability else None
+            ),
+        )
+    return summaries
+
+
+def _fcas_latest_finalized(rows: list[object]) -> FcasLatestFinalizedMetadata | None:
+    if not rows:
+        return None
+    latest = max(rows, key=lambda row: getattr(row, "interval_start"))
+    return FcasLatestFinalizedMetadata(
+        interval_start=getattr(latest, "interval_start"),
+        report_timestamp=getattr(latest, "report_timestamp"),
+        downloaded_at=getattr(latest, "downloaded_at"),
+        source_artifact_sha256=getattr(latest, "source_artifact_sha256"),
+        dispatch_interval=getattr(latest, "dispatch_interval"),
+        intervention=getattr(latest, "intervention"),
+        run_number=getattr(latest, "run_number"),
+    )
+
+
+def _fcas_publication_state(
+    rows: list[object],
+    expected_intervals: int,
+    requested_start: datetime,
+    requested_end: datetime,
+    now: datetime,
+) -> FcasPublicationState:
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise ValueError("FCAS publication clock must be timezone-aware")
+    current_day_start = datetime.combine(
+        now.astimezone(NEM_TIMEZONE).date(),
+        datetime.min.time(),
+        tzinfo=NEM_TIMEZONE,
+    ).astimezone(timezone.utc)
+    if rows:
+        if len(rows) == expected_intervals:
+            return "available"
+        expected_timestamps = set()
+        timestamp = _first_aligned_timestamp(requested_start)
+        while timestamp < requested_end:
+            expected_timestamps.add(timestamp)
+            timestamp += INTERVAL
+        observed_timestamps = {
+            getattr(row, "interval_start")
+            for row in rows
+        }
+        missing_timestamps = expected_timestamps - observed_timestamps
+        if missing_timestamps and all(
+            timestamp >= current_day_start
+            for timestamp in missing_timestamps
+        ):
+            return "not_yet_public"
+        return "partial"
+    current_day_end = current_day_start + timedelta(days=1)
+    if requested_start < current_day_end and requested_end > current_day_start:
+        return "not_yet_public"
+    return "no_data"
+
+
+def _database_fcas(
+    request: Request,
+    generator: str,
+    start: str | None,
+    end: str | None,
+    services: str | None,
+) -> FcasResponse:
+    requested_start, requested_end = _fcas_bounds(start, end)
+    selected_services = _fcas_services(services)
+    found = False
+    result: FcasResponse | None = None
+    try:
+        with request.app.state.repository_provider() as repository:
+            metadata = repository.read_generator(generator)
+            if metadata is not None:
+                found = True
+                rows = _fcas_rows_in_window(
+                    repository.list_fcas(
+                        generator,
+                        start=requested_start,
+                        end=requested_end,
+                    ),
+                    generator,
+                    requested_start,
+                    requested_end,
+                )
+                points, projected = _fcas_projected_points(
+                    rows,
+                    selected_services,
+                    requested_start,
+                    requested_end,
+                )
+                expected_intervals = len(points)
+                observed_intervals = len(rows)
+                result = FcasResponse(
+                    generator=_database_generator(metadata),
+                    requested_start=requested_start,
+                    requested_end=requested_end,
+                    selected_services=list(selected_services),
+                    points=points,
+                    coverage=FcasCoverage(
+                        expected_intervals=expected_intervals,
+                        observed_intervals=observed_intervals,
+                        missing_intervals=expected_intervals - observed_intervals,
+                        coverage_percent=(
+                            observed_intervals / expected_intervals * 100
+                            if expected_intervals
+                            else 0
+                        ),
+                    ),
+                    latest_finalized=_fcas_latest_finalized(rows),
+                    publication_state=_fcas_publication_state(
+                        rows,
+                        expected_intervals,
+                        requested_start,
+                        requested_end,
+                        request.app.state.fcas_clock(),
+                    ),
+                    service_summaries=_fcas_service_summaries(
+                        projected,
+                        selected_services,
+                    ),
+                )
+    except Exception:
+        raise HTTPException(status_code=503, detail="Database FCAS unavailable") from None
+    if not found:
+        raise HTTPException(status_code=404, detail="Unknown generator")
+    assert result is not None
+    return result
 
 
 def _series_response(
@@ -373,6 +721,19 @@ def generators(request: Request) -> GeneratorListResponse:
         ) from None
 
 
+@router.get("/api/fcas", response_model=FcasResponse)
+def fcas(
+    request: Request,
+    generator: str = Query(..., min_length=1),
+    start: str | None = None,
+    end: str | None = None,
+    services: str | None = None,
+) -> FcasResponse:
+    if request.app.state.data_mode != "database":
+        raise HTTPException(status_code=503, detail="Database FCAS unavailable")
+    return _database_fcas(request, generator, start, end, services)
+
+
 @router.get("/api/series", response_model=SeriesResponse)
 def series(
     request: Request,
@@ -423,6 +784,7 @@ def create_app(
     connection_factory: ConnectionFactory | None = None,
     data_mode: str | None = None,
     repository_provider: RepositoryProvider | None = None,
+    clock: Callable[[], datetime] | None = None,
 ) -> FastAPI:
     selected_mode = mode if data_mode is None else data_mode
     if selected_mode not in {"fixture", "database"}:
@@ -439,6 +801,7 @@ def create_app(
     application.state.database_url = configured_url
     application.state.connection_factory = connection_factory
     application.state.repository_provider_injected = repository_provider is not None
+    application.state.fcas_clock = clock or (lambda: datetime.now(timezone.utc))
     application.state.repository_provider = (
         repository_provider
         if repository_provider is not None

--- a/app/backend/batterywatch_api/models.py
+++ b/app/backend/batterywatch_api/models.py
@@ -113,3 +113,87 @@ class SeriesResponse(ApiModel):
     @field_serializer("requested_start", "requested_end")
     def serialize_bounds(self, value: datetime) -> str:
         return utc_iso(value)
+
+
+FcasServiceName = Literal[
+    "raise_1s",
+    "lower_1s",
+    "raise_6s",
+    "lower_6s",
+    "raise_60s",
+    "lower_60s",
+    "raise_5m",
+    "lower_5m",
+    "raise_reg",
+    "lower_reg",
+]
+FcasPublicationState = Literal["available", "partial", "not_yet_public", "no_data"]
+
+
+class FcasServicePoint(ApiModel):
+    target_mw: float | None
+    enablement_status: int | None
+    actual_availability_mw: float | None
+    enabled: bool
+    trapped: bool
+    stranded: bool
+    cleared: bool
+    participating: bool
+    response_verified: Literal[False] = False
+
+
+class FcasPoint(ApiModel):
+    timestamp: datetime
+    services: dict[FcasServiceName, FcasServicePoint]
+
+    @field_serializer("timestamp")
+    def serialize_timestamp(self, value: datetime) -> str:
+        return utc_iso(value)
+
+
+class FcasCoverage(ApiModel):
+    expected_intervals: int = Field(ge=0)
+    observed_intervals: int = Field(ge=0)
+    missing_intervals: int = Field(ge=0)
+    coverage_percent: float = Field(ge=0, le=100)
+
+
+class FcasLatestFinalizedMetadata(ApiModel):
+    interval_start: datetime
+    report_timestamp: datetime
+    downloaded_at: datetime
+    source_artifact_sha256: str
+    dispatch_interval: str
+    intervention: int
+    run_number: int
+
+    @field_serializer("interval_start", "report_timestamp", "downloaded_at")
+    def serialize_timestamp(self, value: datetime) -> str:
+        return utc_iso(value)
+
+
+class FcasServiceSummary(ApiModel):
+    reported_intervals: int = Field(ge=0)
+    enabled_intervals: int = Field(ge=0)
+    cleared_intervals: int = Field(ge=0)
+    participating_intervals: int = Field(ge=0)
+    trapped_intervals: int = Field(ge=0)
+    stranded_intervals: int = Field(ge=0)
+    max_target_mw: float | None = Field(default=None, ge=0)
+    max_actual_availability_mw: float | None = Field(default=None, ge=0)
+
+
+class FcasResponse(ApiModel):
+    generator: Generator
+    requested_start: datetime
+    requested_end: datetime
+    selected_services: list[FcasServiceName]
+    points: list[FcasPoint]
+    coverage: FcasCoverage
+    latest_finalized: FcasLatestFinalizedMetadata | None
+    publication_state: FcasPublicationState
+    service_summaries: dict[FcasServiceName, FcasServiceSummary]
+
+    @field_serializer("requested_start", "requested_end")
+    def serialize_bounds(self, value: datetime) -> str:
+        return utc_iso(value)

--- a/app/backend/batterywatch_api/nested_source_artifacts.py
+++ b/app/backend/batterywatch_api/nested_source_artifacts.py
@@ -35,6 +35,7 @@ class NestedSourceArtifactReceipt:
 class NestedSourceArtifactResult:
     artifact_sha256: str
     byte_count: int
+    downloaded_at: datetime
     replayed: bool
 
 
@@ -165,6 +166,7 @@ class PostgreSQLNestedSourceArtifactRegistrar:
             receipt.outer_source_url,
             None,
         )
+        canonical_downloaded_at = receipt.downloaded_at
         try:
             with _managed_cursor(self._connection) as cursor:
                 cursor.execute(
@@ -208,16 +210,24 @@ class PostgreSQLNestedSourceArtifactRegistrar:
                         receipt.raw_bytes,
                         receipt.parent_artifact_sha256,
                         receipt.artifact_published_at,
-                        receipt.downloaded_at,
                         receipt.publication_id,
                     )
-                    normalized = (*stored[:5], bytes(stored[5]), *stored[6:])
+                    normalized = (
+                        *stored[:5],
+                        bytes(stored[5]),
+                        stored[6],
+                        stored[7],
+                        stored[9],
+                    )
                     if normalized != expected:
                         raise NestedSourceArtifactConflictError(
                             "conflicting nested source artifact"
                         )
+                    canonical_downloaded_at = stored[8]
             self._connection.commit()
-            return NestedSourceArtifactResult(digest, byte_count, not inserted)
+            return NestedSourceArtifactResult(
+                digest, byte_count, canonical_downloaded_at, not inserted
+            )
         except Exception:
             try:
                 self._connection.rollback()

--- a/app/backend/batterywatch_api/nextday_fcas_ingestion.py
+++ b/app/backend/batterywatch_api/nextday_fcas_ingestion.py
@@ -1,0 +1,524 @@
+"""Atomic persistence for grouped FCAS evidence from retained Next Day SOC files."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from typing import Any, Iterator, Protocol
+
+from psycopg.types.json import Jsonb
+
+from .nextday_soc import NextDaySocObservation
+
+
+@dataclass(frozen=True, slots=True)
+class NextDayFcasIngestionResult:
+    """Counts for one grouped FCAS projection ingestion."""
+
+    source_rows: int
+    raw_inserted: int
+    raw_replayed: int
+    effective_candidates: int
+    effective_applied: int
+    effective_replayed: int
+    reported_service_count: int
+
+    @property
+    def fcas_raw_inserted(self) -> int:
+        return self.raw_inserted
+
+    @property
+    def fcas_raw_replayed(self) -> int:
+        return self.raw_replayed
+
+    @property
+    def fcas_effective_candidates(self) -> int:
+        return self.effective_candidates
+
+    @property
+    def fcas_effective_applied(self) -> int:
+        return self.effective_applied
+
+    @property
+    def fcas_effective_replayed(self) -> int:
+        return self.effective_replayed
+
+    @property
+    def fcas_reported_service_count(self) -> int:
+        return self.reported_service_count
+
+
+class NextDayFcasConflictError(Exception):
+    """Raised when stored FCAS evidence conflicts at the same precedence."""
+
+
+class _Cursor(Protocol):
+    rowcount: int
+
+    def execute(self, statement: str, parameters: tuple[Any, ...]) -> None: ...
+
+    def executemany(
+        self,
+        statement: str,
+        parameters: Iterable[tuple[Any, ...]],
+    ) -> None: ...
+
+    def fetchone(self) -> tuple[Any, ...] | None: ...
+
+    def fetchall(self) -> list[tuple[Any, ...]]: ...
+
+    def close(self) -> None: ...
+
+
+class _Connection(Protocol):
+    def cursor(self) -> _Cursor: ...
+
+    def commit(self) -> None: ...
+
+    def rollback(self) -> None: ...
+
+
+@contextmanager
+def _managed_cursor(connection: _Connection) -> Iterator[_Cursor]:
+    cursor = connection.cursor()
+    try:
+        yield cursor
+    finally:
+        cursor.close()
+
+
+_ARTIFACT_SELECT_SQL = """
+SELECT feed
+FROM historical_source_artifacts
+WHERE artifact_sha256 = %s
+FOR SHARE
+"""
+
+_RAW_SELECT_SQL = """
+SELECT artifact_sha256, generator_id, interval_start, fcas_services,
+       intervention, run_number, dispatch_interval, last_changed,
+       report_timestamp, downloaded_at, ingestion_version, correction_version
+FROM raw_nextday_fcas_observations
+WHERE artifact_sha256 = %s
+  AND ingestion_version = %s
+  AND correction_version = %s
+FOR UPDATE
+"""
+
+_RAW_INSERT_SQL = """
+INSERT INTO raw_nextday_fcas_observations (
+    artifact_sha256, generator_id, interval_start, fcas_services,
+    intervention, run_number, dispatch_interval, last_changed,
+    report_timestamp, downloaded_at, ingestion_version, correction_version
+)
+VALUES (%s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s, %s, %s, %s)
+"""
+
+_EFFECTIVE_SELECT_SQL = """
+SELECT generator_id, interval_start, fcas_services, last_changed,
+       report_timestamp, downloaded_at, intervention, run_number,
+       dispatch_interval, ingestion_version, correction_version,
+       source_artifact_sha256
+FROM generator_fcas_5m
+WHERE generator_id = ANY(%s)
+  AND interval_start >= %s
+  AND interval_start <= %s
+FOR UPDATE
+"""
+
+_EFFECTIVE_UPSERT_SQL = """
+INSERT INTO generator_fcas_5m (
+    generator_id, interval_start, fcas_services, last_changed,
+    report_timestamp, downloaded_at, intervention, run_number,
+    dispatch_interval, ingestion_version, correction_version,
+    source_artifact_sha256
+)
+VALUES (
+    %s, %s, %s::jsonb, %s, %s, %s, %s, %s, %s, %s, %s, %s
+)
+ON CONFLICT (generator_id, interval_start) DO UPDATE
+SET fcas_services = EXCLUDED.fcas_services,
+    last_changed = EXCLUDED.last_changed,
+    report_timestamp = EXCLUDED.report_timestamp,
+    downloaded_at = EXCLUDED.downloaded_at,
+    intervention = EXCLUDED.intervention,
+    run_number = EXCLUDED.run_number,
+    dispatch_interval = EXCLUDED.dispatch_interval,
+    ingestion_version = EXCLUDED.ingestion_version,
+    correction_version = EXCLUDED.correction_version,
+    source_artifact_sha256 = EXCLUDED.source_artifact_sha256
+WHERE generator_fcas_5m.source_artifact_sha256 IS NULL
+   OR (
+    (
+    EXCLUDED.intervention,
+    EXCLUDED.correction_version,
+    EXCLUDED.ingestion_version,
+    EXCLUDED.report_timestamp,
+    EXCLUDED.source_artifact_sha256
+) > (
+    generator_fcas_5m.intervention,
+    generator_fcas_5m.correction_version,
+    generator_fcas_5m.ingestion_version,
+    generator_fcas_5m.report_timestamp,
+    generator_fcas_5m.source_artifact_sha256
+    )
+)
+"""
+
+
+def _fcas_map(
+    observation: NextDaySocObservation,
+) -> dict[str, dict[str, float | int | None]]:
+    return observation.fcas.as_dict()
+
+
+def _jsonb_parameter(
+    observation: NextDaySocObservation,
+) -> Jsonb:
+    # Jsonb is required by psycopg for adapting a Python mapping to JSONB.  The
+    # SQL cast also keeps the storage contract explicit for alternate drivers.
+    return Jsonb(_fcas_map(observation))
+
+
+def _raw_parameters(observation: NextDaySocObservation) -> tuple[Any, ...]:
+    return (
+        observation.source_artifact_id,
+        observation.duid,
+        observation.interval_start,
+        _jsonb_parameter(observation),
+        observation.intervention,
+        observation.run_number,
+        observation.dispatch_interval,
+        observation.last_changed,
+        observation.report_timestamp,
+        observation.downloaded_at,
+        observation.ingestion_version,
+        observation.correction_version,
+    )
+
+
+def _precedence(observation: NextDaySocObservation) -> tuple[Any, ...]:
+    return (
+        observation.intervention,
+        observation.correction_version,
+        observation.ingestion_version,
+        observation.report_timestamp,
+        observation.source_artifact_id,
+    )
+
+
+def _json_data(value: Any) -> Any:
+    if isinstance(value, Jsonb):
+        return value.obj
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return None
+    return None
+
+
+def _raw_matches(stored: tuple[Any, ...], expected: tuple[Any, ...]) -> bool:
+    if len(stored) != len(expected):
+        return False
+    return (
+        stored[:3] == expected[:3]
+        and _json_data(stored[3]) == _json_data(expected[3])
+        and stored[4:] == expected[4:]
+    )
+
+
+def _raw_identity(observation: NextDaySocObservation) -> tuple[Any, ...]:
+    return (
+        observation.source_artifact_id,
+        observation.duid,
+        observation.interval_start,
+        observation.intervention,
+        observation.run_number,
+        observation.dispatch_interval,
+        observation.last_changed,
+        observation.report_timestamp,
+        observation.downloaded_at,
+        observation.ingestion_version,
+        observation.correction_version,
+        json.dumps(_fcas_map(observation), sort_keys=True, separators=(",", ":")),
+    )
+
+
+def _effective_parameters(
+    observation: NextDaySocObservation,
+) -> tuple[Any, ...]:
+    return (
+        observation.duid,
+        observation.interval_start,
+        _jsonb_parameter(observation),
+        observation.last_changed,
+        observation.report_timestamp,
+        observation.downloaded_at,
+        observation.intervention,
+        observation.run_number,
+        observation.dispatch_interval,
+        observation.ingestion_version,
+        observation.correction_version,
+        observation.source_artifact_id,
+    )
+
+
+def _effective_precedence(parameters: tuple[Any, ...]) -> tuple[Any, ...]:
+    return (
+        parameters[6],
+        parameters[10],
+        parameters[9],
+        parameters[4],
+        parameters[11],
+    )
+
+
+def _effective_matches(
+    stored: tuple[Any, ...],
+    expected: tuple[Any, ...],
+) -> bool:
+    if len(stored) != len(expected):
+        return False
+    return (
+        stored[:2] == expected[:2]
+        and _json_data(stored[2]) == _json_data(expected[2])
+        and stored[3:] == expected[3:]
+    )
+
+
+def _validate_inputs(
+    observations: tuple[NextDaySocObservation, ...],
+) -> None:
+    if not observations or any(
+        not isinstance(item, NextDaySocObservation) for item in observations
+    ):
+        raise ValueError("invalid Next Day FCAS observations")
+
+    first = observations[0]
+    if any(
+        item.source_artifact_id != first.source_artifact_id
+        or item.ingestion_version != first.ingestion_version
+        or item.correction_version != first.correction_version
+        or item.report_timestamp != first.report_timestamp
+        or item.downloaded_at != first.downloaded_at
+        for item in observations
+    ):
+        raise ValueError("mixed Next Day FCAS source identity")
+
+    seen: set[tuple[Any, ...]] = set()
+    for item in observations:
+        key = (
+            item.source_artifact_id,
+            item.duid,
+            item.interval_start,
+            item.intervention,
+            item.run_number,
+            item.ingestion_version,
+            item.correction_version,
+        )
+        if key in seen:
+            raise ValueError("duplicate Next Day FCAS natural key")
+        seen.add(key)
+
+
+def _select_effective_candidates(
+    observations: tuple[NextDaySocObservation, ...],
+) -> tuple[NextDaySocObservation, ...]:
+    grouped: dict[tuple[str, datetime], list[NextDaySocObservation]] = {}
+    for item in observations:
+        grouped.setdefault((item.duid, item.interval_start), []).append(item)
+
+    selected: list[NextDaySocObservation] = []
+    for key, candidates in grouped.items():
+        winner_precedence = max(_precedence(item) for item in candidates)
+        winners = [
+            item for item in candidates
+            if _precedence(item) == winner_precedence
+        ]
+        winner_payloads = {_raw_identity(item) for item in winners}
+        if len(winner_payloads) != 1:
+            raise NextDayFcasConflictError(
+                f"conflicting effective Next Day FCAS candidates for {key[0]}"
+            )
+        selected.append(winners[0])
+    return tuple(sorted(selected, key=lambda item: (item.duid, item.interval_start)))
+
+
+class PostgreSQLNextDayFcasIngestor:
+    """Persist grouped FCAS evidence without registering a second artifact."""
+
+    def __init__(self, connection: _Connection):
+        self._connection = connection
+
+    def ingest(
+        self,
+        observations: Iterable[NextDaySocObservation],
+    ) -> NextDayFcasIngestionResult:
+        try:
+            materialized = tuple(observations)
+            _validate_inputs(materialized)
+            effective_candidates = _select_effective_candidates(materialized)
+            first = materialized[0]
+
+            with _managed_cursor(self._connection) as cursor:
+                cursor.execute(_ARTIFACT_SELECT_SQL, (first.source_artifact_id,))
+                artifact = cursor.fetchone()
+                if artifact != ("nextday_soc",):
+                    raise ValueError("artifact is not registered as nextday_soc")
+
+                cursor.execute(
+                    _RAW_SELECT_SQL,
+                    (
+                        first.source_artifact_id,
+                        first.ingestion_version,
+                        first.correction_version,
+                    ),
+                )
+                stored_raw = {
+                    (
+                        row[0],
+                        row[1],
+                        row[2],
+                        row[4],
+                        row[5],
+                        row[10],
+                        row[11],
+                    ): tuple(row)
+                    for row in cursor.fetchall()
+                }
+                raw_missing: list[tuple[Any, ...]] = []
+                raw_replayed = 0
+                for observation in materialized:
+                    parameters = _raw_parameters(observation)
+                    key = (
+                        parameters[0],
+                        parameters[1],
+                        parameters[2],
+                        parameters[4],
+                        parameters[5],
+                        parameters[10],
+                        parameters[11],
+                    )
+                    stored = stored_raw.get(key)
+                    if stored is None:
+                        raw_missing.append(parameters)
+                    elif _raw_matches(stored, parameters):
+                        raw_replayed += 1
+                    else:
+                        raise NextDayFcasConflictError(
+                            "stored raw Next Day FCAS conflicts with source"
+                        )
+
+                duids = sorted({item.duid for item in effective_candidates})
+                intervals = [item.interval_start for item in effective_candidates]
+                cursor.execute(
+                    _EFFECTIVE_SELECT_SQL,
+                    (duids, min(intervals), max(intervals)),
+                )
+                stored_effective = {
+                    (row[0], row[1]): tuple(row)
+                    for row in cursor.fetchall()
+                }
+
+                effective_apply: list[tuple[Any, ...]] = []
+                effective_replayed = 0
+                for observation in effective_candidates:
+                    parameters = _effective_parameters(observation)
+                    stored = stored_effective.get((parameters[0], parameters[1]))
+                    if stored is None:
+                        effective_apply.append(parameters)
+                        continue
+                    if stored[11] is None:
+                        effective_apply.append(parameters)
+                        continue
+                    candidate_precedence = _effective_precedence(parameters)
+                    stored_precedence = _effective_precedence(stored)
+                    if candidate_precedence > stored_precedence:
+                        effective_apply.append(parameters)
+                    elif candidate_precedence == stored_precedence:
+                        if not _effective_matches(stored, parameters):
+                            raise NextDayFcasConflictError(
+                                "stored effective Next Day FCAS conflicts at equal precedence"
+                            )
+                        effective_replayed += 1
+                    else:
+                        effective_replayed += 1
+
+                if raw_missing:
+                    cursor.executemany(_RAW_INSERT_SQL, raw_missing)
+                    raw_inserted = cursor.rowcount
+                    if raw_inserted != len(raw_missing):
+                        raise NextDayFcasConflictError(
+                            "raw Next Day FCAS bulk write was incomplete"
+                        )
+                else:
+                    raw_inserted = 0
+
+                if effective_apply:
+                    cursor.executemany(_EFFECTIVE_UPSERT_SQL, effective_apply)
+                    effective_applied = cursor.rowcount
+                    if not 0 <= effective_applied <= len(effective_apply):
+                        raise NextDayFcasConflictError(
+                            "invalid effective Next Day FCAS bulk result"
+                        )
+                    if effective_applied < len(effective_apply):
+                        cursor.execute(
+                            _EFFECTIVE_SELECT_SQL,
+                            (duids, min(intervals), max(intervals)),
+                        )
+                        final_effective = {
+                            (row[0], row[1]): tuple(row)
+                            for row in cursor.fetchall()
+                        }
+                        for parameters in effective_apply:
+                            stored = final_effective.get(
+                                (parameters[0], parameters[1])
+                            )
+                            if stored is None or stored[11] is None:
+                                raise NextDayFcasConflictError(
+                                    "guarded effective Next Day FCAS write is missing"
+                                )
+                            candidate_precedence = _effective_precedence(parameters)
+                            stored_precedence = _effective_precedence(stored)
+                            if stored_precedence < candidate_precedence or (
+                                stored_precedence == candidate_precedence
+                                and not _effective_matches(stored, parameters)
+                            ):
+                                raise NextDayFcasConflictError(
+                                    "guarded effective Next Day FCAS write conflicts"
+                                )
+                    effective_replayed += len(effective_apply) - effective_applied
+                else:
+                    effective_applied = 0
+
+            self._connection.commit()
+            return NextDayFcasIngestionResult(
+                source_rows=len(materialized),
+                raw_inserted=raw_inserted,
+                raw_replayed=raw_replayed,
+                effective_candidates=len(effective_candidates),
+                effective_applied=effective_applied,
+                effective_replayed=effective_replayed,
+                reported_service_count=sum(
+                    item.fcas.reported_service_count for item in materialized
+                ),
+            )
+        except Exception:
+            try:
+                self._connection.rollback()
+            except Exception:
+                pass
+            raise
+
+
+__all__ = [
+    "NextDayFcasConflictError",
+    "NextDayFcasIngestionResult",
+    "PostgreSQLNextDayFcasIngestor",
+]

--- a/app/backend/batterywatch_api/nextday_soc.py
+++ b/app/backend/batterywatch_api/nextday_soc.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import csv
-from dataclasses import dataclass
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from io import StringIO
 from math import isfinite
+from types import MappingProxyType
 import re
 from typing import Literal
 
@@ -28,6 +30,48 @@ _REQUIRED_COLUMNS = frozenset(
 _DUID_RE = re.compile(r"^[A-Z0-9_]{1,32}$")
 _ARTIFACT_RE = re.compile(r"^[0-9a-f]{64}$")
 _DISPATCH_INTERVAL_RE = re.compile(r"^(\d{8})(\d{3})$")
+
+# These are the only FCAS service identities retained by this source path.  The
+# UnitSolution reports use the corresponding AEMO column names below.
+FCAS_SERVICES = (
+    "raise_1s",
+    "lower_1s",
+    "raise_6s",
+    "lower_6s",
+    "raise_60s",
+    "lower_60s",
+    "raise_5m",
+    "lower_5m",
+    "raise_reg",
+    "lower_reg",
+)
+FCAS_CLEARANCE_EPSILON_MW = 0.000001
+
+# UnitSolution flags observed in the retained v5/v6 source are the bounded
+# integer status codes 0 through 4.  1 and 3 are enabled, 3 is trapped, and 4
+# is stranded.  Rejecting every other value prevents an unknown source code
+# from being mistaken for a valid FCAS state.
+_SUPPORTED_FCAS_STATUS_FLAGS = frozenset((0, 1, 2, 3, 4))
+_FCAS_COLUMNS = {
+    "raise_1s": ("RAISE1SEC", "RAISE1SECFLAGS", "RAISE1SECACTUALAVAILABILITY"),
+    "lower_1s": ("LOWER1SEC", "LOWER1SECFLAGS", "LOWER1SECACTUALAVAILABILITY"),
+    "raise_6s": ("RAISE6SEC", "RAISE6SECFLAGS", "RAISE6SECACTUALAVAILABILITY"),
+    "lower_6s": ("LOWER6SEC", "LOWER6SECFLAGS", "LOWER6SECACTUALAVAILABILITY"),
+    "raise_60s": (
+        "RAISE60SEC",
+        "RAISE60SECFLAGS",
+        "RAISE60SECACTUALAVAILABILITY",
+    ),
+    "lower_60s": (
+        "LOWER60SEC",
+        "LOWER60SECFLAGS",
+        "LOWER60SECACTUALAVAILABILITY",
+    ),
+    "raise_5m": ("RAISE5MIN", "RAISE5MINFLAGS", "RAISE5MINACTUALAVAILABILITY"),
+    "lower_5m": ("LOWER5MIN", "LOWER5MINFLAGS", "LOWER5MINACTUALAVAILABILITY"),
+    "raise_reg": ("RAISEREG", "RAISEREGFLAGS", "RAISEREGACTUALAVAILABILITY"),
+    "lower_reg": ("LOWERREG", "LOWERREGFLAGS", "LOWERREGACTUALAVAILABILITY"),
+}
 
 
 class NextDaySocParseError(ValueError):
@@ -75,6 +119,43 @@ def _soc_mwh(value: str) -> float | None:
     return parsed
 
 
+def _fcas_mw(value: str | None, field: str) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise NextDaySocParseError(f"invalid {field}") from exc
+    if not isfinite(parsed) or parsed < 0:
+        raise NextDaySocParseError(f"invalid {field}")
+    return parsed
+
+
+def _fcas_status(value: str | None, field: str) -> int | None:
+    if value is None or value == "":
+        return None
+    if not value.isascii() or not value.isdecimal():
+        raise NextDaySocParseError(f"invalid {field}")
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise NextDaySocParseError(f"invalid {field}") from exc
+    if parsed not in _SUPPORTED_FCAS_STATUS_FLAGS:
+        raise NextDaySocParseError(f"unsupported {field}")
+    return parsed
+
+
+def _fcas_service(
+    values: Mapping[str, str], service: str
+) -> NextDayFcasServiceObservation:
+    target_column, status_column, actual_column = _FCAS_COLUMNS[service]
+    return NextDayFcasServiceObservation(
+        target_mw=_fcas_mw(values.get(target_column), target_column),
+        enablement_status=_fcas_status(values.get(status_column), status_column),
+        actual_availability_mw=_fcas_mw(values.get(actual_column), actual_column),
+    )
+
+
 def _dispatch_interval(value: str, interval_start: datetime) -> str:
     match = _DISPATCH_INTERVAL_RE.fullmatch(value)
     if match is None:
@@ -106,8 +187,177 @@ def _validated_downloaded_at(value: datetime, report_timestamp: datetime) -> dat
 
 
 @dataclass(frozen=True, slots=True)
+class NextDayFcasServiceObservation:
+    """Raw FCAS evidence for one canonical UnitSolution service."""
+
+    target_mw: float | None = None
+    enablement_status: int | None = None
+    actual_availability_mw: float | None = None
+
+    def __post_init__(self) -> None:
+        for value, field_name in (
+            (self.target_mw, "target_mw"),
+            (self.actual_availability_mw, "actual_availability_mw"),
+        ):
+            if value is None:
+                continue
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(f"invalid FCAS {field_name}")
+            try:
+                normalized = float(value)
+            except (OverflowError, ValueError) as exc:
+                raise ValueError(f"invalid FCAS {field_name}") from exc
+            if not isfinite(normalized) or normalized < 0:
+                raise ValueError(f"invalid FCAS {field_name}")
+        status = self.enablement_status
+        if status is not None and (
+            isinstance(status, bool)
+            or type(status) is not int
+            or status not in _SUPPORTED_FCAS_STATUS_FLAGS
+        ):
+            raise ValueError("invalid FCAS enablement_status")
+
+    @property
+    def enabled(self) -> bool:
+        return self.enablement_status in {1, 3}
+
+    @property
+    def trapped(self) -> bool:
+        return self.enablement_status == 3
+
+    @property
+    def stranded(self) -> bool:
+        return self.enablement_status == 4
+
+    @property
+    def cleared(self) -> bool:
+        return (
+            self.target_mw is not None
+            and self.target_mw > FCAS_CLEARANCE_EPSILON_MW
+        )
+
+    @property
+    def participating(self) -> bool:
+        return self.enabled and self.cleared
+
+    @property
+    def response_evidence(self) -> None:
+        """UnitSolution has no measured physical response evidence."""
+
+        return None
+
+    @property
+    def reported(self) -> bool:
+        return any(
+            value is not None
+            for value in (
+                self.target_mw,
+                self.enablement_status,
+                self.actual_availability_mw,
+            )
+        )
+
+
+def _empty_fcas_services() -> dict[str, NextDayFcasServiceObservation]:
+    return {
+        service: NextDayFcasServiceObservation()
+        for service in FCAS_SERVICES
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class NextDayFcasObservation:
+    """The fixed ten-service FCAS map attached to one UnitSolution row."""
+
+    services: Mapping[str, NextDayFcasServiceObservation] = field(
+        default_factory=lambda: MappingProxyType(_empty_fcas_services())
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.services, Mapping):
+            raise ValueError("invalid FCAS service map")
+        if set(self.services) != set(FCAS_SERVICES) or any(
+            not isinstance(self.services.get(service), NextDayFcasServiceObservation)
+            for service in FCAS_SERVICES
+        ):
+            raise ValueError("invalid FCAS service map")
+        normalized = {
+            service: self.services[service]
+            for service in FCAS_SERVICES
+        }
+        object.__setattr__(self, "services", MappingProxyType(normalized))
+
+    @classmethod
+    def empty(cls) -> NextDayFcasObservation:
+        return cls(_empty_fcas_services())
+
+    def __getitem__(self, service: str) -> NextDayFcasServiceObservation:
+        return self.services[service]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.services)
+
+    def __len__(self) -> int:
+        return len(self.services)
+
+    @property
+    def reported_service_count(self) -> int:
+        return sum(service.reported for service in self.services.values())
+
+    def as_dict(self) -> dict[str, dict[str, float | int | None]]:
+        return {
+            service: {
+                "target_mw": evidence.target_mw,
+                "enablement_status": evidence.enablement_status,
+                "actual_availability_mw": evidence.actual_availability_mw,
+            }
+            for service, evidence in self.services.items()
+        }
+
+    @property
+    def raise_1s(self) -> NextDayFcasServiceObservation:
+        return self.services["raise_1s"]
+
+    @property
+    def lower_1s(self) -> NextDayFcasServiceObservation:
+        return self.services["lower_1s"]
+
+    @property
+    def raise_6s(self) -> NextDayFcasServiceObservation:
+        return self.services["raise_6s"]
+
+    @property
+    def lower_6s(self) -> NextDayFcasServiceObservation:
+        return self.services["lower_6s"]
+
+    @property
+    def raise_60s(self) -> NextDayFcasServiceObservation:
+        return self.services["raise_60s"]
+
+    @property
+    def lower_60s(self) -> NextDayFcasServiceObservation:
+        return self.services["lower_60s"]
+
+    @property
+    def raise_5m(self) -> NextDayFcasServiceObservation:
+        return self.services["raise_5m"]
+
+    @property
+    def lower_5m(self) -> NextDayFcasServiceObservation:
+        return self.services["lower_5m"]
+
+    @property
+    def raise_reg(self) -> NextDayFcasServiceObservation:
+        return self.services["raise_reg"]
+
+    @property
+    def lower_reg(self) -> NextDayFcasServiceObservation:
+        return self.services["lower_reg"]
+
+
+@dataclass(frozen=True, slots=True)
 class NextDaySocObservation:
-    """One authoritative per-DUID initial energy storage observation."""
+    """One authoritative per-DUID SOC and FCAS observation."""
 
     duid: str
     interval_start: datetime
@@ -121,6 +371,13 @@ class NextDaySocObservation:
     downloaded_at: datetime
     ingestion_version: int
     correction_version: int
+    fcas: NextDayFcasObservation = field(
+        default_factory=NextDayFcasObservation.empty
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.fcas, NextDayFcasObservation):
+            raise ValueError("invalid Next Day FCAS observation")
 
     @property
     def publication_latency_seconds(self) -> int:
@@ -236,6 +493,12 @@ def parse_nextday_unit_solution_soc(
                     downloaded_at=downloaded,
                     ingestion_version=ingestion,
                     correction_version=correction,
+                    fcas=NextDayFcasObservation(
+                        {
+                            service: _fcas_service(values, service)
+                            for service in FCAS_SERVICES
+                        }
+                    ),
                 )
             )
     except (csv.Error, TypeError, UnicodeError) as exc:
@@ -260,6 +523,10 @@ def parse_nextday_unit_solution_soc(
 
 
 __all__ = [
+    "FCAS_CLEARANCE_EPSILON_MW",
+    "FCAS_SERVICES",
+    "NextDayFcasObservation",
+    "NextDayFcasServiceObservation",
     "NextDaySocObservation",
     "NextDaySocParseError",
     "parse_nextday_unit_solution_soc",

--- a/app/backend/batterywatch_api/storage.py
+++ b/app/backend/batterywatch_api/storage.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from decimal import Decimal
+import json
 from math import isfinite
-from collections.abc import Hashable, Iterable, Iterator, MutableMapping
+from collections.abc import Hashable, Iterable, Iterator, Mapping, MutableMapping
+from types import MappingProxyType
 from typing import Any, Literal, Protocol, TypeVar
 
 UTC = timezone.utc
@@ -47,7 +50,7 @@ def _number(value: float, field: str) -> float:
         raise ValueError(f"{field} must be numeric")
     try:
         normalized = float(value)
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{field} must be numeric") from exc
     if not isfinite(normalized):
         raise ValueError(f"{field} must be finite")
@@ -334,6 +337,173 @@ class RegionalPrice5m(_VersionedRecord):
         return self.price_aud_per_mwh is not None and self.price_aud_per_mwh < 0
 
 
+FCAS_SERVICES = (
+    "raise_1s",
+    "lower_1s",
+    "raise_6s",
+    "lower_6s",
+    "raise_60s",
+    "lower_60s",
+    "raise_5m",
+    "lower_5m",
+    "raise_reg",
+    "lower_reg",
+)
+FCAS_CLEARANCE_EPSILON_MW = 0.000001
+_VALID_FCAS_STATUS_FLAGS = frozenset((0, 1, 2, 3, 4))
+
+
+def _fcas_number(value: object, field: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float, Decimal)):
+        raise ValueError(f"{field} must be numeric")
+    try:
+        normalized = float(value)
+    except (OverflowError, ValueError) as exc:
+        raise ValueError(f"{field} must be numeric") from exc
+    if not isfinite(normalized):
+        raise ValueError(f"{field} must be finite")
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class FcasService5m:
+    """One service's grouped FCAS evidence for an effective interval."""
+
+    target_mw: float | None = None
+    enablement_status: int | None = None
+    actual_availability_mw: float | None = None
+
+    def __post_init__(self) -> None:
+        target = _fcas_number(self.target_mw, "target_mw")
+        actual = _fcas_number(
+            self.actual_availability_mw, "actual_availability_mw"
+        )
+        if target is not None and target < 0:
+            raise ValueError("target_mw must be non-negative")
+        if actual is not None and actual < 0:
+            raise ValueError("actual_availability_mw must be non-negative")
+        status = self.enablement_status
+        if status is not None and (
+            isinstance(status, bool)
+            or type(status) is not int
+            or status not in _VALID_FCAS_STATUS_FLAGS
+        ):
+            raise ValueError("enablement_status must be a supported integer")
+        object.__setattr__(self, "target_mw", target)
+        object.__setattr__(self, "actual_availability_mw", actual)
+
+    @property
+    def reported(self) -> bool:
+        return any(
+            value is not None
+            for value in (
+                self.target_mw,
+                self.enablement_status,
+                self.actual_availability_mw,
+            )
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return self.enablement_status in (1, 3)
+
+    @property
+    def trapped(self) -> bool:
+        return self.enablement_status == 3
+
+    @property
+    def stranded(self) -> bool:
+        return self.enablement_status == 4
+
+    @property
+    def cleared(self) -> bool:
+        return (
+            self.target_mw is not None
+            and self.target_mw > FCAS_CLEARANCE_EPSILON_MW
+        )
+
+    @property
+    def participating(self) -> bool:
+        return self.cleared and self.enabled
+
+
+@dataclass(frozen=True, slots=True)
+class GeneratorFcas5m(_VersionedRecord):
+    """One effective grouped FCAS record per generator and interval."""
+
+    generator_id: str
+    interval_start: datetime
+    services: Mapping[str, FcasService5m]
+    last_changed: datetime
+    report_timestamp: datetime
+    downloaded_at: datetime
+    intervention: int
+    run_number: int
+    dispatch_interval: str
+    ingestion_version: int
+    correction_version: int
+    source_artifact_sha256: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "generator_id", _text(self.generator_id, "generator_id"))
+        object.__setattr__(self, "interval_start", aligned_5m(self.interval_start))
+        if not isinstance(self.services, Mapping):
+            raise ValueError("services must be a mapping")
+        if set(self.services) != set(FCAS_SERVICES):
+            raise ValueError("services must contain the canonical FCAS services")
+        if any(
+            not isinstance(self.services[service], FcasService5m)
+            for service in FCAS_SERVICES
+        ):
+            raise ValueError("services must contain typed FCAS values")
+        object.__setattr__(
+            self,
+            "services",
+            MappingProxyType(
+                {service: self.services[service] for service in FCAS_SERVICES}
+            ),
+        )
+        last_changed = utc_timestamp(self.last_changed, "last_changed")
+        report_timestamp = utc_timestamp(self.report_timestamp, "report_timestamp")
+        downloaded_at = utc_timestamp(self.downloaded_at, "downloaded_at")
+        if last_changed > report_timestamp:
+            raise ValueError("last_changed must not follow report_timestamp")
+        if report_timestamp > downloaded_at:
+            raise ValueError("report_timestamp must not follow downloaded_at")
+        object.__setattr__(self, "last_changed", last_changed)
+        object.__setattr__(self, "report_timestamp", report_timestamp)
+        object.__setattr__(self, "downloaded_at", downloaded_at)
+        if type(self.intervention) is not int or self.intervention not in (0, 1):
+            raise ValueError("intervention must be 0 or 1")
+        object.__setattr__(self, "run_number", _version(self.run_number, "run_number"))
+        if self.run_number == 0:
+            raise ValueError("run_number must be positive")
+        object.__setattr__(
+            self,
+            "dispatch_interval",
+            _text(self.dispatch_interval, "dispatch_interval"),
+        )
+        ingestion = _version(self.ingestion_version, "ingestion_version")
+        correction = _version(self.correction_version, "correction_version")
+        object.__setattr__(self, "ingestion_version", ingestion)
+        object.__setattr__(self, "correction_version", correction)
+        object.__setattr__(
+            self,
+            "source_artifact_sha256",
+            _text(self.source_artifact_sha256, "source_artifact_sha256"),
+        )
+
+    @property
+    def logical_key(self) -> tuple[str, datetime]:
+        return (self.generator_id, self.interval_start)
+
+    @property
+    def timestamp(self) -> datetime:
+        return self.interval_start
+
+
 # Short aliases make the contract convenient without losing the table-shaped names.
 GeneratorRecord = GeneratorMetadata
 PowerRecord = GeneratorPower5m
@@ -369,6 +539,13 @@ class StorageRepository(Protocol):
         start: datetime | None = None,
         end: datetime | None = None,
     ) -> tuple[GeneratorSoc5m, ...]: ...
+
+    def list_fcas(
+        self,
+        generator_id: str,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> tuple[GeneratorFcas5m, ...]: ...
 
     def list_prices(
         self,
@@ -421,6 +598,7 @@ class InMemoryRepository:
         self._generators: dict[tuple[str], GeneratorMetadata] = {}
         self._power: dict[tuple[str, datetime], GeneratorPower5m] = {}
         self._soc: dict[tuple[str, datetime], GeneratorSoc5m] = {}
+        self._fcas: dict[tuple[str, datetime], GeneratorFcas5m] = {}
         self._prices: dict[tuple[str, datetime], RegionalPrice5m] = {}
 
     def upsert_generator(self, record: GeneratorMetadata) -> bool:
@@ -486,6 +664,23 @@ class InMemoryRepository:
         values = [
             record
             for (record_dimension, interval_start), record in self._soc.items()
+            if record_dimension == dimension
+            and (normalized_start is None or interval_start >= normalized_start)
+            and (normalized_end is None or interval_start < normalized_end)
+        ]
+        return tuple(sorted(values, key=lambda record: record.interval_start))
+
+    def list_fcas(
+        self,
+        generator_id: str,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> tuple[GeneratorFcas5m, ...]:
+        dimension = _text(generator_id, "generator_id")
+        normalized_start, normalized_end = _window(start, end)
+        values = [
+            record
+            for (record_dimension, interval_start), record in self._fcas.items()
             if record_dimension == dimension
             and (normalized_start is None or interval_start >= normalized_start)
             and (normalized_end is None or interval_start < normalized_end)
@@ -726,6 +921,18 @@ WHERE generator_id = %s
 ORDER BY interval_start ASC
 """
 
+_FCAS_LIST_SQL = """
+SELECT generator_id, interval_start, fcas_services,
+       last_changed, report_timestamp, downloaded_at,
+       intervention, run_number, dispatch_interval,
+       ingestion_version, correction_version, source_artifact_sha256
+FROM generator_fcas_5m
+WHERE generator_id = %s
+  AND (%s::timestamptz IS NULL OR interval_start >= %s::timestamptz)
+  AND (%s::timestamptz IS NULL OR interval_start < %s::timestamptz)
+ORDER BY interval_start ASC
+"""
+
 _PRICE_LIST_SQL = """
 SELECT region, interval_start, price_aud_per_mwh, price_status,
        intervention, apc_flag, market_suspended, source_id, source_timestamp,
@@ -793,6 +1000,55 @@ def _price_from_row(row: tuple[Any, ...]) -> RegionalPrice5m:
         ingestion_version=row[9],
         correction_version=row[10],
         quality_flags=tuple(row[11] or ()),
+    )
+
+
+def _fcas_services_from_value(value: Any) -> dict[str, FcasService5m]:
+    if hasattr(value, "obj"):
+        value = value.obj
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise ValueError("invalid stored FCAS service map") from exc
+    if not isinstance(value, Mapping) or set(value) != set(FCAS_SERVICES):
+        raise ValueError("invalid stored FCAS service map")
+    services: dict[str, FcasService5m] = {}
+    for service in FCAS_SERVICES:
+        raw = value.get(service)
+        if isinstance(raw, FcasService5m):
+            services[service] = raw
+        elif isinstance(raw, Mapping):
+            if set(raw) != {
+                "target_mw",
+                "enablement_status",
+                "actual_availability_mw",
+            }:
+                raise ValueError("invalid stored FCAS service value")
+            services[service] = FcasService5m(
+                target_mw=raw.get("target_mw"),
+                enablement_status=raw.get("enablement_status"),
+                actual_availability_mw=raw.get("actual_availability_mw"),
+            )
+        else:
+            raise ValueError("invalid stored FCAS service value")
+    return services
+
+
+def _fcas_from_row(row: tuple[Any, ...]) -> GeneratorFcas5m:
+    return GeneratorFcas5m(
+        generator_id=row[0],
+        interval_start=row[1],
+        services=_fcas_services_from_value(row[2]),
+        last_changed=row[3],
+        report_timestamp=row[4],
+        downloaded_at=row[5],
+        intervention=row[6],
+        run_number=row[7],
+        dispatch_interval=row[8],
+        ingestion_version=row[9],
+        correction_version=row[10],
+        source_artifact_sha256=row[11],
     )
 
 
@@ -976,6 +1232,23 @@ class PostgreSQLRepository:
         ]
         return tuple(sorted(values, key=lambda record: record.interval_start))
 
+    def list_fcas(
+        self,
+        generator_id: str,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> tuple[GeneratorFcas5m, ...]:
+        dimension = _text(generator_id, "generator_id")
+        normalized_start, normalized_end = _window(start, end)
+        values = [
+            _fcas_from_row(row)
+            for row in self._many(
+                _FCAS_LIST_SQL,
+                self._window_parameters(dimension, normalized_start, normalized_end),
+            )
+        ]
+        return tuple(sorted(values, key=lambda record: record.interval_start))
+
     def list_prices(
         self,
         region: str,
@@ -1006,6 +1279,10 @@ __all__ = [
     "GeneratorMetadata",
     "GeneratorPower5m",
     "GeneratorSoc5m",
+    "FcasService5m",
+    "GeneratorFcas5m",
+    "FCAS_SERVICES",
+    "FCAS_CLEARANCE_EPSILON_MW",
     "RegionalPrice5m",
     "RecordProvenance",
     "StorageRepository",

--- a/app/backend/tests/test_api_fcas.py
+++ b/app/backend/tests/test_api_fcas.py
@@ -1,0 +1,653 @@
+"""Focused database FCAS API contract tests."""
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+import unittest
+from typing import cast
+
+from fastapi.testclient import TestClient
+
+import batterywatch_api.main as main
+from batterywatch_api.storage import (
+    FCAS_SERVICES,
+    FcasService5m,
+    GeneratorFcas5m,
+    GeneratorMetadata,
+    InMemoryRepository,
+    PostgreSQLConnection,
+    PostgreSQLRepository,
+    StorageRepository,
+)
+
+UTC = timezone.utc
+START = datetime(2026, 1, 1, tzinfo=UTC)
+END = datetime(2026, 1, 1, 0, 5, tzinfo=UTC)
+SERVICES = (
+    "raise_1s",
+    "lower_1s",
+    "raise_6s",
+    "lower_6s",
+    "raise_60s",
+    "lower_60s",
+    "raise_5m",
+    "lower_5m",
+    "raise_reg",
+    "lower_reg",
+)
+
+
+def _metadata() -> GeneratorMetadata:
+    return GeneratorMetadata(
+        generator_id="DB-FCAS",
+        site_name="FCAS Battery",
+        region="NSW1",
+        capacity_mw=2.0,
+        storage_capacity_mwh=4.0,
+        source_id="registry",
+        source_timestamp=START,
+        ingestion_version=1,
+    )
+
+
+def _fcas_row(
+    interval_start: datetime = START,
+    *,
+    changes: dict[str, tuple[float | None, int | None, float | None]] | None = None,
+) -> GeneratorFcas5m:
+    changed = changes or {
+        "raise_6s": (0.0, 1, 0.0),
+    }
+    values = {
+        service: FcasService5m(
+            target_mw=None,
+            enablement_status=None,
+            actual_availability_mw=None,
+        )
+        for service in SERVICES
+    }
+    for service, value in changed.items():
+        values[service] = FcasService5m(*value)
+    return GeneratorFcas5m(
+        generator_id="DB-FCAS",
+        interval_start=interval_start,
+        services=values,
+        last_changed=interval_start,
+        report_timestamp=interval_start + timedelta(hours=1),
+        downloaded_at=interval_start + timedelta(hours=2),
+        intervention=0,
+        run_number=1,
+        dispatch_interval="20260101001",
+        ingestion_version=1,
+        correction_version=0,
+        source_artifact_sha256="a" * 64,
+    )
+
+
+class DatabaseFcasApiTests(unittest.TestCase):
+    def test_storage_repository_declares_the_bounded_fcas_read(self):
+        method = getattr(StorageRepository, "list_fcas", None)
+        self.assertTrue(callable(method))
+
+    def _client(
+        self,
+        rows=(),
+        *,
+        clock=lambda: datetime(2026, 1, 1, 12, tzinfo=UTC),
+        read_generator=None,
+        list_fcas=None,
+    ):
+        metadata = _metadata()
+
+        @contextmanager
+        def provider():
+            class Repository(InMemoryRepository):
+                def read_generator(self, generator_id):
+                    return metadata if read_generator is None else read_generator(generator_id)
+
+                def list_fcas(self, generator_id, start=None, end=None):
+                    if list_fcas is not None:
+                        return list_fcas(generator_id, start, end)
+                    return tuple(rows)
+
+            yield Repository()
+
+        return TestClient(
+            main.create_app(
+                mode="database",
+                health_tracer=lambda: True,
+                repository_provider=provider,
+                clock=clock,
+            )
+        )
+
+    def test_grouped_point_preserves_null_and_explicit_zero_service_values(self):
+        @contextmanager
+        def provider():
+            class Repository(InMemoryRepository):
+                def read_generator(self, generator_id):
+                    return _metadata()
+
+                def list_fcas(self, generator_id, start=None, end=None):
+                    return (_fcas_row(),)
+
+            yield Repository()
+
+        response = TestClient(
+            main.create_app(
+                mode="database",
+                health_tracer=lambda: True,
+                repository_provider=provider,
+            )
+        ).get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": START.isoformat().replace("+00:00", "Z"),
+                "end": END.isoformat().replace("+00:00", "Z"),
+                "services": "raise_1s,raise_6s",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["selected_services"], ["raise_1s", "raise_6s"])
+        self.assertEqual(len(body["points"]), 1)
+        self.assertEqual(
+            set(body["points"][0]["services"]),
+            {"raise_1s", "raise_6s"},
+        )
+        self.assertIsNone(
+            body["points"][0]["services"]["raise_1s"]["target_mw"]
+        )
+        self.assertEqual(
+            body["points"][0]["services"]["raise_6s"]["target_mw"],
+            0.0,
+        )
+        self.assertEqual(
+            body["points"][0]["services"]["raise_6s"]["actual_availability_mw"],
+            0.0,
+        )
+        self.assertFalse(body["points"][0]["services"]["raise_6s"]["response_verified"])
+
+    def test_range_and_service_filter_are_validated_before_storage_reads(self):
+        calls = []
+
+        def list_fcas(generator_id, start, end):
+            calls.append((generator_id, start, end))
+            return ()
+
+        client = self._client(list_fcas=list_fcas)
+        base = {"generator": "DB-FCAS"}
+        invalid_requests = (
+            base,
+            base | {"start": "2026-01-01T00:00:00", "end": "2026-01-01T00:05:00Z"},
+            base | {"start": "2026-01-01T00:05:00Z", "end": "2026-01-01T00:00:00Z"},
+            base
+            | {
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-31T00:00:01Z",
+            },
+        )
+        for params in invalid_requests:
+            with self.subTest(params=params):
+                self.assertEqual(client.get("/api/fcas", params=params).status_code, 400)
+        for service_filter in ("", "raise_1s,raise_1s", "unknown", "raise_1s, raise_6s"):
+            with self.subTest(service_filter=service_filter):
+                response = client.get(
+                    "/api/fcas",
+                    params=base
+                    | {
+                        "start": "2026-01-01T00:00:00Z",
+                        "end": "2026-01-01T00:05:00Z",
+                        "services": service_filter,
+                    },
+                )
+                self.assertEqual(response.status_code, 400)
+        self.assertEqual(calls, [])
+
+    def test_exact_thirty_day_range_is_allowed_and_one_second_over_is_rejected(self):
+        client = self._client()
+        exact = client.get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-31T00:00:00Z",
+            },
+        )
+        self.assertEqual(exact.status_code, 200)
+        over = client.get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-31T00:00:01Z",
+            },
+        )
+        self.assertEqual(over.status_code, 400)
+
+    def test_unknown_generator_is_checked_before_fcas_rows(self):
+        calls = []
+
+        def read_generator(generator_id):
+            calls.append(("generator", generator_id))
+            return None
+
+        def list_fcas(generator_id, start, end):
+            calls.append(("fcas", generator_id, start, end))
+            return (_fcas_row(),)
+
+        response = self._client(
+            read_generator=read_generator,
+            list_fcas=list_fcas,
+        ).get(
+            "/api/fcas",
+            params={
+                "generator": "NOPE",
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-01T00:05:00Z",
+            },
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(calls, [("generator", "NOPE")])
+
+    def test_default_response_uses_all_canonical_services_in_canonical_order(self):
+        body = self._client(rows=(_fcas_row(),)).get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-01T00:05:00Z",
+            },
+        ).json()
+        self.assertEqual(body["selected_services"], list(FCAS_SERVICES))
+        self.assertEqual(set(body["points"][0]["services"]), set(FCAS_SERVICES))
+        self.assertEqual(set(body["service_summaries"]), set(FCAS_SERVICES))
+
+    def test_classification_preserves_enabled_trapped_stranded_and_epsilon_states(self):
+        row = _fcas_row(
+            changes={
+                "raise_1s": (2.0, 1, 0.0),
+                "lower_1s": (2.0, 3, 0.0),
+                "raise_6s": (2.0, 4, 0.0),
+                "lower_6s": (0.000001, 1, 0.0),
+            }
+        )
+        body = self._client(rows=(row,)).get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-01T00:05:00Z",
+                "services": "raise_1s,lower_1s,raise_6s,lower_6s",
+            },
+        ).json()
+        values = body["points"][0]["services"]
+        self.assertTrue(values["raise_1s"]["enabled"])
+        self.assertTrue(values["raise_1s"]["cleared"])
+        self.assertTrue(values["raise_1s"]["participating"])
+        self.assertTrue(values["lower_1s"]["enabled"])
+        self.assertTrue(values["lower_1s"]["trapped"])
+        self.assertTrue(values["lower_1s"]["participating"])
+        self.assertFalse(values["raise_6s"]["enabled"])
+        self.assertTrue(values["raise_6s"]["stranded"])
+        self.assertTrue(values["raise_6s"]["cleared"])
+        self.assertFalse(values["raise_6s"]["participating"])
+        self.assertFalse(values["lower_6s"]["cleared"])
+        self.assertFalse(values["lower_6s"]["participating"])
+        self.assertFalse(values["raise_6s"]["response_verified"])
+
+    def test_service_summaries_include_enabled_counts_and_availability_maximum(self):
+        rows = (
+            _fcas_row(
+                START,
+                changes={
+                    "raise_1s": (2.0, 1, 1.5),
+                },
+            ),
+            _fcas_row(
+                START + timedelta(minutes=5),
+                changes={
+                    "raise_1s": (1.0, 3, 2.5),
+                },
+            ),
+        )
+        body = self._client(rows=rows).get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-01T00:10:00Z",
+                "services": "raise_1s",
+            },
+        ).json()
+
+        self.assertEqual(
+            body["service_summaries"]["raise_1s"]["enabled_intervals"],
+            2,
+        )
+        self.assertEqual(
+            body["service_summaries"]["raise_1s"]["max_actual_availability_mw"],
+            2.5,
+        )
+
+    def test_filtering_keeps_grouped_intervals_and_summaries(self):
+        rows = (
+            _fcas_row(
+                START,
+                changes={
+                    "raise_1s": (None, None, None),
+                    "raise_6s": (0.0, 1, 0.0),
+                    "lower_6s": (2.0, 3, 0.0),
+                },
+            ),
+            _fcas_row(
+                START + timedelta(minutes=10),
+                changes={
+                    "raise_1s": (1.0, 4, 0.0),
+                    "raise_6s": (3.0, 1, 0.0),
+                },
+            ),
+        )
+        calls = []
+
+        def list_fcas(generator_id, start, end):
+            calls.append((generator_id, start, end))
+            return rows
+
+        response = self._client(
+            list_fcas=list_fcas,
+            clock=lambda: datetime(2026, 1, 2, tzinfo=UTC),
+        ).get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-01T00:15:00Z",
+                "services": "raise_1s,raise_6s",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["selected_services"], ["raise_1s", "raise_6s"])
+        self.assertEqual(len(body["points"]), 3)
+        self.assertEqual(
+            [point["timestamp"] for point in body["points"]],
+            [
+                "2026-01-01T00:00:00Z",
+                "2026-01-01T00:05:00Z",
+                "2026-01-01T00:10:00Z",
+            ],
+        )
+        self.assertEqual(
+            body["points"][0]["services"]["raise_6s"]["target_mw"], 0.0
+        )
+        self.assertFalse(body["points"][0]["services"]["raise_6s"]["cleared"])
+        self.assertIsNone(
+            body["points"][1]["services"]["raise_6s"]["target_mw"]
+        )
+        self.assertEqual(
+            body["points"][2]["services"]["raise_1s"]["target_mw"], 1.0
+        )
+        self.assertTrue(body["points"][2]["services"]["raise_1s"]["cleared"])
+        self.assertTrue(body["points"][2]["services"]["raise_1s"]["stranded"])
+        self.assertFalse(body["points"][2]["services"]["raise_1s"]["participating"])
+        self.assertEqual(body["coverage"]["expected_intervals"], 3)
+        self.assertEqual(body["coverage"]["observed_intervals"], 2)
+        self.assertEqual(body["coverage"]["missing_intervals"], 1)
+        self.assertAlmostEqual(body["coverage"]["coverage_percent"], 200 / 3)
+        self.assertEqual(
+            body["service_summaries"]["raise_1s"],
+            {
+                "reported_intervals": 1,
+                "enabled_intervals": 0,
+                "cleared_intervals": 1,
+                "participating_intervals": 0,
+                "trapped_intervals": 0,
+                "stranded_intervals": 1,
+                "max_target_mw": 1.0,
+                "max_actual_availability_mw": 0.0,
+            },
+        )
+        self.assertEqual(
+            body["service_summaries"]["raise_6s"],
+            {
+                "reported_intervals": 2,
+                "enabled_intervals": 2,
+                "cleared_intervals": 1,
+                "participating_intervals": 1,
+                "trapped_intervals": 0,
+                "stranded_intervals": 0,
+                "max_target_mw": 3.0,
+                "max_actual_availability_mw": 0.0,
+            },
+        )
+        self.assertEqual(
+            body["latest_finalized"]["interval_start"],
+            "2026-01-01T00:10:00Z",
+        )
+        self.assertEqual(body["publication_state"], "partial")
+        self.assertEqual(calls, [("DB-FCAS", START, START + timedelta(minutes=15))])
+
+    def test_mixed_window_with_only_current_nem_day_gap_is_not_yet_public(self):
+        row = _fcas_row(datetime(2026, 1, 1, 13, 55, tzinfo=UTC))
+        response = self._client(
+            rows=(row,),
+            clock=lambda: datetime(2026, 1, 1, 14, 5, tzinfo=UTC),
+        ).get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2026-01-01T13:55:00Z",
+                "end": "2026-01-01T14:05:00Z",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["coverage"]["expected_intervals"], 2)
+        self.assertEqual(body["coverage"]["observed_intervals"], 1)
+        self.assertEqual(body["coverage"]["missing_intervals"], 1)
+        self.assertEqual(body["publication_state"], "not_yet_public")
+
+    def test_mixed_historical_and_current_nem_day_gaps_remain_partial(self):
+        row = _fcas_row(datetime(2026, 1, 1, 13, 50, tzinfo=UTC))
+        response = self._client(
+            rows=(row,),
+            clock=lambda: datetime(2026, 1, 1, 14, 5, tzinfo=UTC),
+        ).get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2026-01-01T13:50:00Z",
+                "end": "2026-01-01T14:05:00Z",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["coverage"]["missing_intervals"], 2)
+        self.assertEqual(body["publication_state"], "partial")
+
+    def test_current_day_and_historical_empty_windows_have_honest_publication_states(self):
+        current_clock = lambda: datetime(2026, 1, 1, 12, tzinfo=UTC)
+        current = self._client(clock=current_clock).get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-01T00:05:00Z",
+            },
+        )
+        self.assertEqual(current.status_code, 200)
+        self.assertEqual(current.json()["publication_state"], "not_yet_public")
+        self.assertIsNone(
+            current.json()["points"][0]["services"]["raise_1s"]["target_mw"]
+        )
+        before_nem_midnight = self._client(
+            clock=lambda: datetime(2026, 1, 1, 13, 59, tzinfo=UTC)
+        ).get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2026-01-01T13:55:00Z",
+                "end": "2026-01-01T14:00:00Z",
+            },
+        )
+        self.assertEqual(
+            before_nem_midnight.json()["publication_state"],
+            "not_yet_public",
+        )
+        after_nem_midnight = self._client(
+            clock=lambda: datetime(2026, 1, 1, 14, tzinfo=UTC)
+        ).get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2026-01-01T13:55:00Z",
+                "end": "2026-01-01T14:00:00Z",
+            },
+        )
+        self.assertEqual(
+            after_nem_midnight.json()["publication_state"],
+            "no_data",
+        )
+        historical = self._client(clock=current_clock).get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2025-12-31T00:00:00Z",
+                "end": "2025-12-31T00:05:00Z",
+            },
+        )
+        self.assertEqual(historical.status_code, 200)
+        self.assertEqual(historical.json()["publication_state"], "no_data")
+        self.assertNotIn("inactive", current.text.lower())
+        self.assertNotIn("inactive", historical.text.lower())
+
+    def test_storage_and_mapping_failures_are_generic_503s(self):
+        failure_marker = "fcas-storage-marker"
+        secret_marker = "postgresql://fcas-secret.invalid/batterywatch"
+
+        def failed_list(generator_id, start, end):
+            raise RuntimeError(f"{failure_marker}: {secret_marker}")
+
+        storage_response = self._client(list_fcas=failed_list).get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-01T00:05:00Z",
+            },
+        )
+        self.assertEqual(storage_response.status_code, 503)
+        self.assertEqual(storage_response.json(), {"detail": "Database FCAS unavailable"})
+        self.assertNotIn(failure_marker, storage_response.text)
+        self.assertNotIn(secret_marker, storage_response.text)
+
+        bad_row = SimpleNamespace(interval_start=START, services={})
+        mapping_response = self._client(list_fcas=lambda *_: (bad_row,)).get(
+            "/api/fcas",
+            params={
+                "generator": "DB-FCAS",
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-01T00:05:00Z",
+            },
+        )
+        self.assertEqual(mapping_response.status_code, 503)
+        self.assertEqual(mapping_response.json(), {"detail": "Database FCAS unavailable"})
+
+    def test_fixture_mode_does_not_fallback_to_fixture_fcas(self):
+        calls = []
+
+        def provider():
+            calls.append("called")
+            raise AssertionError("fixture FCAS must not use a database provider")
+
+        response = TestClient(
+            main.create_app(repository_provider=provider)
+        ).get(
+            "/api/fcas",
+            params={
+                "generator": "BWTEST1",
+                "start": "2026-01-01T00:00:00Z",
+                "end": "2026-01-01T00:05:00Z",
+            },
+        )
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(calls, [])
+
+
+class PostgreSQLFcasStorageTests(unittest.TestCase):
+    def test_list_fcas_reads_only_bounded_effective_grouped_rows(self):
+        service_map: dict[str, dict[str, float | int | None]] = {
+            service: {
+                "target_mw": None,
+                "enablement_status": None,
+                "actual_availability_mw": None,
+            }
+            for service in FCAS_SERVICES
+        }
+        service_map["raise_6s"] = {
+            "target_mw": 0.0,
+            "enablement_status": 1,
+            "actual_availability_mw": 0.0,
+        }
+        row = (
+            "DB-FCAS",
+            START,
+            service_map,
+            START,
+            START + timedelta(hours=1),
+            START + timedelta(hours=2),
+            0,
+            1,
+            "20260101001",
+            1,
+            0,
+            "a" * 64,
+        )
+
+        class Cursor:
+            def __init__(self, connection):
+                self.connection = connection
+                self.rows = []
+
+            def execute(self, statement, parameters):
+                self.connection.execution = (statement, tuple(parameters))
+                self.rows = [row]
+
+            def fetchall(self):
+                return self.rows
+
+            def close(self):
+                self.connection.closed = True
+
+        class Connection:
+            def __init__(self):
+                self.closed = False
+                self.execution: tuple[str, tuple[object, ...]] | None = None
+
+            def cursor(self):
+                return Cursor(self)
+
+        connection = Connection()
+        values = PostgreSQLRepository(cast(PostgreSQLConnection, connection)).list_fcas(
+            "DB-FCAS", start=START, end=END
+        )
+        self.assertEqual(len(values), 1)
+        self.assertEqual(values[0].services["raise_6s"].target_mw, 0.0)
+        self.assertIsNone(values[0].services["raise_1s"].target_mw)
+        self.assertIsNotNone(connection.execution)
+        assert connection.execution is not None
+        statement, parameters = connection.execution
+        self.assertIn("FROM generator_fcas_5m", statement)
+        self.assertNotIn("FROM raw_nextday_fcas_observations", statement)
+        self.assertIn("interval_start < %s::timestamptz", statement)
+        self.assertEqual(parameters, ("DB-FCAS", START, START, END, END))
+        self.assertTrue(connection.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/backend/tests/test_backfill_ledger.py
+++ b/app/backend/tests/test_backfill_ledger.py
@@ -246,6 +246,10 @@ class PostgreSQLBackfillLedgerTests(unittest.TestCase):
                 claim.attempt_number,
             ),
         )
+        self.assertIn(
+            "jsonb_build_object('error_summary', %s::text)",
+            connection.executions[2][0],
+        )
         self.assertEqual(
             connection.executions[2][1],
             (
@@ -308,6 +312,10 @@ class PostgreSQLBackfillLedgerTests(unittest.TestCase):
         self.assertEqual(
             connection.executions[1][1],
             (claim.run_id, claim.feed, claim.report_date, claim.attempt_number),
+        )
+        self.assertIn(
+            "jsonb_build_object('records_imported', %s::bigint)",
+            connection.executions[2][0],
         )
         self.assertEqual(
             connection.executions[2][1],

--- a/app/backend/tests/test_backfill_ledger.py
+++ b/app/backend/tests/test_backfill_ledger.py
@@ -87,8 +87,8 @@ class BackfillLedgerMigrationTests(unittest.TestCase):
             self.assertIn(f"'{table}'", migrate_script)
 
         self.assertIn("004_historical_backfill_ledger.sql", migrate_script)
-        self.assertIn("SELECT count(*) = 13", migrate_script)
-        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 10)
+        self.assertIn("SELECT count(*) = 15", migrate_script)
+        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 11)
         self.assertIn("ON DELETE RESTRICT", migration)
         self.assertIn("event_seq BIGSERIAL PRIMARY KEY", migration)
         self.assertIn("historical_backfill_items_claim_idx", migration)

--- a/app/backend/tests/test_dispatch_price_ingestion.py
+++ b/app/backend/tests/test_dispatch_price_ingestion.py
@@ -247,11 +247,11 @@ class DispatchPriceMigrationTests(unittest.TestCase):
         self.assertIn("raw_zip BYTEA NOT NULL", migration)
         self.assertIn("PUBLIC_DISPATCHIS_", migration)
         self.assertIn("003_dispatch_price_artifacts.sql", migrate_script)
-        self.assertIn("SELECT count(*) = 13", migrate_script)
+        self.assertIn("SELECT count(*) = 15", migrate_script)
         self.assertIn("'dispatch_price_artifacts'", migrate_script)
         self.assertIn("004_historical_backfill_ledger.sql", migrate_script)
         self.assertIn("database_url=$BATTERYWATCH_DATABASE_URL", migrate_script)
-        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 10)
+        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 11)
         self.assertNotIn("export PGDATABASE=", migrate_script)
 
 

--- a/app/backend/tests/test_historical_artifact_migration.py
+++ b/app/backend/tests/test_historical_artifact_migration.py
@@ -235,8 +235,6 @@ class HistoricalArtifactMigrationTests(unittest.TestCase):
         self.assertIn("CREATE TABLE IF NOT EXISTS generator_fcas_5m", migration)
         self.assertIn("fcas_services JSONB NOT NULL", migration)
         self.assertIn("nextday_fcas_map_jsonb_valid", migration)
-        self.assertIn("jsonb_object_length(value) <> 3", migration)
-        self.assertIn("jsonb_object_length(value) <> 10", migration)
         self.assertIn("value ?& ARRAY", migration)
         self.assertIn("(value -> 'target_mw') < '0'::jsonb", migration)
         self.assertIn("(value -> 'actual_availability_mw') < '0'::jsonb", migration)
@@ -310,6 +308,43 @@ class HistoricalArtifactMigrationTests(unittest.TestCase):
         self.assertIn("SELECT count(*) = 15", migrate_script)
         self.assertIn("'raw_nextday_fcas_observations'", migrate_script)
         self.assertIn("'generator_fcas_5m'", migrate_script)
+        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 11)
+        for forbidden in ("DROP TABLE", "DROP COLUMN", "TRUNCATE ", "DELETE FROM"):
+            self.assertNotIn(forbidden, upper)
+
+    def test_replaces_fcas_validators_with_supported_additive_migration(self) -> None:
+        app_root = Path(__file__).resolve().parents[2]
+        migration_path = app_root / "migrations" / "011_fcas_validator_compatibility.sql"
+        self.assertTrue(
+            migration_path.exists(),
+            "011 FCAS validator compatibility migration is missing",
+        )
+
+        migration = migration_path.read_text(encoding="utf-8")
+        migrate_script = (app_root / "deploy" / "migrate.sh").read_text(
+            encoding="utf-8"
+        )
+        upper = migration.upper()
+
+        self.assertIn("BEGIN;", upper)
+        self.assertIn("COMMIT;", upper)
+        for function_name in (
+            "nextday_fcas_service_jsonb_valid",
+            "nextday_fcas_map_jsonb_valid",
+        ):
+            self.assertIn(
+                f"CREATE OR REPLACE FUNCTION {function_name}",
+                migration,
+            )
+        self.assertIn("jsonb_object_keys(value)", migration)
+        self.assertIn("COUNT(*)", upper)
+        self.assertNotIn("jsonb_object_length", migration)
+        self.assertIn("010_nextday_fcas.sql", migrate_script)
+        self.assertIn("011_fcas_validator_compatibility.sql", migrate_script)
+        self.assertLess(
+            migrate_script.index("010_nextday_fcas.sql"),
+            migrate_script.index("011_fcas_validator_compatibility.sql"),
+        )
         self.assertEqual(migrate_script.count('--dbname="$database_url"'), 11)
         for forbidden in ("DROP TABLE", "DROP COLUMN", "TRUNCATE ", "DELETE FROM"):
             self.assertNotIn(forbidden, upper)

--- a/app/backend/tests/test_historical_artifact_migration.py
+++ b/app/backend/tests/test_historical_artifact_migration.py
@@ -46,10 +46,10 @@ class HistoricalArtifactMigrationTests(unittest.TestCase):
 
         self.assertIn("004_historical_backfill_ledger.sql", migrate_script)
         self.assertIn("005_historical_source_artifacts.sql", migrate_script)
-        self.assertIn("SELECT count(*) = 13", migrate_script)
+        self.assertIn("SELECT count(*) = 15", migrate_script)
         for table in ("historical_source_artifacts", "historical_backfill_item_artifacts"):
             self.assertIn(f"'{table}'", migrate_script)
-        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 10)
+        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 11)
 
         upper = migration.upper()
         for forbidden in ("DROP ", "ALTER ", "TRUNCATE "):
@@ -88,7 +88,7 @@ class HistoricalArtifactMigrationTests(unittest.TestCase):
         ):
             self.assertIn(f"'{event_type}'", migration)
         self.assertIn("006_artifact_recorded_event.sql", migrate_script)
-        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 10)
+        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 11)
         self.assertNotIn("TRUNCATE ", upper)
         self.assertNotRegex(upper, r"\bDELETE\s+FROM\b")
 
@@ -115,7 +115,7 @@ class HistoricalArtifactMigrationTests(unittest.TestCase):
         self.assertIn("historical_backfill_events_details_check", migration)
         self.assertIn("jsonb_typeof(details) = 'object'", migration)
         self.assertIn("007_backfill_runtime_details.sql", migrate_script)
-        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 10)
+        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 11)
         self.assertNotIn("TRUNCATE ", upper)
         self.assertNotRegex(upper, r"\bDELETE\s+FROM\b")
 
@@ -214,9 +214,103 @@ class HistoricalArtifactMigrationTests(unittest.TestCase):
             migrate_script.index("007_backfill_runtime_details.sql"),
             migrate_script.index("008_authoritative_soc.sql"),
         )
-        self.assertIn("SELECT count(*) = 13", migrate_script)
+        self.assertIn("SELECT count(*) = 15", migrate_script)
         self.assertIn("'raw_nextday_soc_observations'", migrate_script)
-        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 10)
+        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 11)
+        for forbidden in ("DROP TABLE", "DROP COLUMN", "TRUNCATE ", "DELETE FROM"):
+            self.assertNotIn(forbidden, upper)
+
+    def test_adds_grouped_nextday_fcas_raw_and_effective_schema(self) -> None:
+        app_root = Path(__file__).resolve().parents[2]
+        migration_path = app_root / "migrations" / "010_nextday_fcas.sql"
+        self.assertTrue(migration_path.exists(), "010 Next Day FCAS migration is missing")
+
+        migration = migration_path.read_text(encoding="utf-8")
+        migrate_script = (app_root / "deploy" / "migrate.sh").read_text(encoding="utf-8")
+        upper = migration.upper()
+
+        self.assertIn("BEGIN;", upper)
+        self.assertIn("COMMIT;", upper)
+        self.assertIn("CREATE TABLE IF NOT EXISTS raw_nextday_fcas_observations", migration)
+        self.assertIn("CREATE TABLE IF NOT EXISTS generator_fcas_5m", migration)
+        self.assertIn("fcas_services JSONB NOT NULL", migration)
+        self.assertIn("nextday_fcas_map_jsonb_valid", migration)
+        self.assertIn("jsonb_object_length(value) <> 3", migration)
+        self.assertIn("jsonb_object_length(value) <> 10", migration)
+        self.assertIn("value ?& ARRAY", migration)
+        self.assertIn("(value -> 'target_mw') < '0'::jsonb", migration)
+        self.assertIn("(value -> 'actual_availability_mw') < '0'::jsonb", migration)
+        self.assertIn("target_type NOT IN ('null', 'number')", migration)
+        self.assertIn("status_type NOT IN ('null', 'number')", migration)
+        self.assertIn("actual_type NOT IN ('null', 'number')", migration)
+        self.assertIn(
+            "NOT IN ('0', '1', '2', '3', '4')",
+            migration,
+        )
+        self.assertNotIn("::DOUBLE PRECISION", upper)
+        self.assertIn("CREATE OR REPLACE FUNCTION", upper)
+        self.assertEqual(migration.count("CREATE TABLE IF NOT EXISTS"), 2)
+        self.assertEqual(migration.count("CREATE INDEX IF NOT EXISTS"), 4)
+        self.assertIn("PRIMARY KEY (generator_id, interval_start)", migration)
+        self.assertIn(
+            "PRIMARY KEY (\n        artifact_sha256,\n        generator_id,\n        interval_start,",
+            migration,
+        )
+        for service in (
+            "raise_1s",
+            "lower_1s",
+            "raise_6s",
+            "lower_6s",
+            "raise_60s",
+            "lower_60s",
+            "raise_5m",
+            "lower_5m",
+            "raise_reg",
+            "lower_reg",
+        ):
+            self.assertIn(service, migration)
+        for field in ("target_mw", "enablement_status", "actual_availability_mw"):
+            self.assertIn(f"'{field}'", migration)
+        for column in (
+            "artifact_sha256",
+            "generator_id",
+            "interval_start",
+            "intervention",
+            "run_number",
+            "dispatch_interval",
+            "last_changed",
+            "report_timestamp",
+            "downloaded_at",
+            "ingestion_version",
+            "correction_version",
+            "source_artifact_sha256",
+        ):
+            self.assertIn(column, migration)
+        for constraint in (
+            "CHECK (intervention IN (0, 1))",
+            "CHECK (run_number > 0)",
+            "CHECK (ingestion_version >= 0)",
+            "CHECK (correction_version >= 0)",
+            "CHECK (last_changed <= report_timestamp)",
+            "CHECK (report_timestamp <= downloaded_at)",
+        ):
+            self.assertGreaterEqual(migration.count(constraint), 2)
+        self.assertIn("UNIQUE (", migration)
+        self.assertIn("REFERENCES historical_source_artifacts", migration)
+        self.assertIn("REFERENCES generators", migration)
+        self.assertIn("ON DELETE RESTRICT", migration)
+        self.assertIn("raw_nextday_fcas_observations_artifact_time_idx", migration)
+        self.assertIn("raw_nextday_fcas_observations_generator_time_idx", migration)
+        self.assertIn("generator_fcas_5m_time_idx", migration)
+        self.assertIn("010_nextday_fcas.sql", migrate_script)
+        self.assertLess(
+            migrate_script.index("009_allow_archive_urls.sql"),
+            migrate_script.index("010_nextday_fcas.sql"),
+        )
+        self.assertIn("SELECT count(*) = 15", migrate_script)
+        self.assertIn("'raw_nextday_fcas_observations'", migrate_script)
+        self.assertIn("'generator_fcas_5m'", migrate_script)
+        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 11)
         for forbidden in ("DROP TABLE", "DROP COLUMN", "TRUNCATE ", "DELETE FROM"):
             self.assertNotIn(forbidden, upper)
 
@@ -246,7 +340,7 @@ class HistoricalArtifactMigrationTests(unittest.TestCase):
             migrate_script.index("008_authoritative_soc.sql"),
             migrate_script.index("009_allow_archive_urls.sql"),
         )
-        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 10)
+        self.assertEqual(migrate_script.count('--dbname="$database_url"'), 11)
         for forbidden in ("DROP TABLE", "DROP COLUMN", "TRUNCATE ", "DELETE FROM"):
             self.assertNotIn(forbidden, upper)
 

--- a/app/backend/tests/test_historical_backfill.py
+++ b/app/backend/tests/test_historical_backfill.py
@@ -148,6 +148,7 @@ class HistoricalBackfillTests(unittest.TestCase):
             claim: BackfillClaim,
             range_start: datetime,
             range_end: datetime,
+            *,
             ingestion_version: int,
         ) -> HistoricalNextDayBackfillResult:
             self.assertEqual(

--- a/app/backend/tests/test_historical_nextday_backfill.py
+++ b/app/backend/tests/test_historical_nextday_backfill.py
@@ -72,6 +72,7 @@ class FakeOuterRegistrar:
 class FakeNestedRegistrar:
     receipts = []
     replayed = False
+    canonical_downloaded_at: datetime | None = None
 
     def __init__(self, connection) -> None:
         pass
@@ -79,8 +80,11 @@ class FakeNestedRegistrar:
     def record(self, receipt):
         self.receipts.append(receipt)
         digest = hashlib.sha256(receipt.raw_bytes).hexdigest()
+        downloaded_at = self.canonical_downloaded_at
+        if downloaded_at is None:
+            downloaded_at = receipt.downloaded_at
         return NestedSourceArtifactResult(
-            digest, len(receipt.raw_bytes), self.replayed
+            digest, len(receipt.raw_bytes), downloaded_at, self.replayed
         )
 
 
@@ -104,6 +108,7 @@ class HistoricalNextDayBackfillTests(unittest.TestCase):
         FakeOuterRegistrar.replayed = False
         FakeNestedRegistrar.receipts = []
         FakeNestedRegistrar.replayed = False
+        FakeNestedRegistrar.canonical_downloaded_at = None
 
     def test_validates_all_selected_daily_reports_before_first_ingest(self) -> None:
         raw_outer = b"monthly outer"
@@ -193,7 +198,9 @@ class HistoricalNextDayBackfillTests(unittest.TestCase):
         )
         members = (_member(1), _member(2))
         manifest = NextDayMonthlyArchiveManifest(reference, "a" * 64, members)
-        parse_calls: list[tuple[str, int]] = []
+        canonical_downloaded_at = datetime(2026, 8, 29, tzinfo=UTC)
+        FakeNestedRegistrar.canonical_downloaded_at = canonical_downloaded_at
+        parse_calls: list[tuple[str, int, datetime]] = []
         read_calls: list[int] = []
         ingest_calls: list[tuple[object, ...]] = []
 
@@ -214,7 +221,13 @@ class HistoricalNextDayBackfillTests(unittest.TestCase):
             )
 
         def parse(payload, **kwargs):
-            parse_calls.append((payload, kwargs["correction_version"]))
+            parse_calls.append(
+                (
+                    payload,
+                    kwargs["correction_version"],
+                    kwargs["downloaded_at"],
+                )
+            )
             day = int(payload[-1])
             return (
                 SimpleNamespace(
@@ -261,10 +274,10 @@ class HistoricalNextDayBackfillTests(unittest.TestCase):
         self.assertEqual(
             parse_calls,
             [
-                ("day-1", 47_000_001),
-                ("day-2", 47_000_002),
-                ("day-1", 47_000_001),
-                ("day-2", 47_000_002),
+                ("day-1", 47_000_001, canonical_downloaded_at),
+                ("day-2", 47_000_002, canonical_downloaded_at),
+                ("day-1", 47_000_001, canonical_downloaded_at),
+                ("day-2", 47_000_002, canonical_downloaded_at),
             ],
         )
         self.assertEqual([len(call) for call in ingest_calls], [1, 1])

--- a/app/backend/tests/test_historical_nextday_backfill.py
+++ b/app/backend/tests/test_historical_nextday_backfill.py
@@ -24,6 +24,7 @@ from batterywatch_api.nextday_monthly_extraction import (
     NextDayDailyMemberRef,
     NextDayMonthlyArchiveManifest,
 )
+from batterywatch_api.nextday_fcas_ingestion import NextDayFcasIngestionResult
 from batterywatch_api.nextday_soc_ingestion import NextDaySocIngestionResult
 
 UTC = timezone.utc
@@ -277,6 +278,144 @@ class HistoricalNextDayBackfillTests(unittest.TestCase):
             HistoricalNextDayBackfillResult(
                 "a" * 64, False, 2, 0, 2, 2, 0, 2, 2, 0, 0, 2
             ),
+        )
+
+    def test_one_daily_artifact_drives_soc_and_fcas_and_fcas_failure_does_not_complete(self) -> None:
+        raw_outer = b"monthly outer"
+        downloaded_at = datetime(2026, 8, 30, tzinfo=UTC)
+        member = _member(1)
+        reference = NextDayMonthlyArchiveRef(
+            date(2025, 7, 1),
+            "PUBLIC_NEXT_DAY_DISPATCH_20250701.zip",
+            OUTER_URL,
+            len(raw_outer),
+            downloaded_at,
+        )
+        manifest = NextDayMonthlyArchiveManifest(reference, "a" * 64, (member,))
+        source_observation = SimpleNamespace(
+            interval_start=datetime(2025, 7, 1, 12, tzinfo=UTC),
+            fcas=object(),
+        )
+        soc_calls: list[tuple[object, ...]] = []
+        fcas_calls: list[tuple[object, ...]] = []
+        events: list[str] = []
+
+        def read_daily(received_manifest, payload, received_member):
+            raw = b"zip-1"
+            return NextDayDailyArtifact(
+                received_member,
+                hashlib.sha256(raw).hexdigest(),
+                raw,
+                received_member.filename.removesuffix(".zip") + ".CSV",
+                b"day-1",
+            )
+
+        def parse(payload, **kwargs):
+            return (source_observation,)
+
+        class SocIngestor:
+            def __init__(self, connection):
+                pass
+
+            def ingest(self, observations, assets):
+                events.append("soc")
+                soc_calls.append(tuple(observations))
+                return NextDaySocIngestionResult(1, 1, 0, 1, 1, 0, 0, 1)
+
+        class FcasIngestor:
+            def __init__(self, connection):
+                pass
+
+            def ingest(self, observations):
+                events.append("fcas")
+                fcas_calls.append(tuple(observations))
+                return NextDayFcasIngestionResult(1, 1, 0, 1, 1, 0, 10)
+
+        claim = BackfillClaim(
+            "soc-fcas-202507",
+            "nextday_soc",
+            date(2025, 7, 1),
+            OUTER_URL,
+            1,
+        )
+        result = run_nextday_soc_backfill_claim(
+            "postgresql://redacted",
+            ASSETS,
+            claim,
+            datetime(2025, 7, 1, tzinfo=UTC),
+            datetime(2025, 7, 1, 14, tzinfo=UTC),
+            ingestion_version=3,
+            connect=lambda *args, **kwargs: FakeConnection(),
+            fetch=lambda url, **kwargs: NemwebHttpResource(
+                url, url, raw_outer, "application/zip", None, None
+            ),
+            clock=lambda: downloaded_at,
+            ledger_factory=FakeLedger,
+            registrar_factory=FakeOuterRegistrar,
+            nested_registrar_factory=FakeNestedRegistrar,
+            validate_archive=lambda ref, payload: manifest,
+            read_daily=read_daily,
+            parse_csv=parse,
+            ingestor_factory=SocIngestor,
+            fcas_ingestor_factory=FcasIngestor,
+        )
+
+        self.assertEqual(soc_calls, [(source_observation,)])
+        self.assertEqual(fcas_calls, [(source_observation,)])
+        self.assertEqual(events, ["soc", "fcas"])
+        self.assertEqual(
+            FakeLedger.completions,
+            [(claim.run_id, BackfillItemCompletion(False, 1))],
+        )
+        self.assertEqual(FakeLedger.failures, [])
+        self.assertEqual(result.fcas_raw_inserted, 1)
+        self.assertEqual(result.fcas_effective_applied, 1)
+        self.assertEqual(result.fcas_reported_service_count, 10)
+
+        FakeLedger.completions = []
+        FakeLedger.failures = []
+        events.clear()
+
+        class FailingFcasIngestor(FcasIngestor):
+            def ingest(self, observations):
+                events.append("fcas")
+                fcas_calls.append(tuple(observations))
+                raise RuntimeError("FCAS projection failed")
+
+        failed_claim = BackfillClaim(
+            "soc-fcas-failed-202507",
+            "nextday_soc",
+            date(2025, 7, 1),
+            OUTER_URL,
+            1,
+        )
+        with self.assertRaisesRegex(RuntimeError, "FCAS projection failed"):
+            run_nextday_soc_backfill_claim(
+                "postgresql://redacted",
+                ASSETS,
+                failed_claim,
+                datetime(2025, 7, 1, tzinfo=UTC),
+                datetime(2025, 7, 1, 14, tzinfo=UTC),
+                ingestion_version=3,
+                connect=lambda *args, **kwargs: FakeConnection(),
+                fetch=lambda url, **kwargs: NemwebHttpResource(
+                    url, url, raw_outer, "application/zip", None, None
+                ),
+                clock=lambda: downloaded_at,
+                ledger_factory=FakeLedger,
+                registrar_factory=FakeOuterRegistrar,
+                nested_registrar_factory=FakeNestedRegistrar,
+                validate_archive=lambda ref, payload: manifest,
+                read_daily=read_daily,
+                parse_csv=parse,
+                ingestor_factory=SocIngestor,
+                fcas_ingestor_factory=FailingFcasIngestor,
+            )
+        self.assertEqual(events, ["soc", "fcas"])
+        self.assertEqual(FakeLedger.completions, [])
+        self.assertEqual(
+            FakeLedger.failures,
+            [(failed_claim.run_id, "RuntimeError")],
         )
 
     def test_exact_replay_is_classified_deterministically(self) -> None:

--- a/app/backend/tests/test_nested_source_artifacts.py
+++ b/app/backend/tests/test_nested_source_artifacts.py
@@ -80,7 +80,9 @@ class PostgreSQLNestedSourceArtifactRegistrarTests(unittest.TestCase):
 
         self.assertEqual(
             result,
-            NestedSourceArtifactResult(digest, len(evidence.raw_bytes), False),
+            NestedSourceArtifactResult(
+                digest, len(evidence.raw_bytes), evidence.downloaded_at, False
+            ),
         )
         self.assertEqual((connection.commits, connection.rollbacks), (1, 0))
         self.assertEqual((connection.cursor_calls, connection.closed_cursors), (1, 1))
@@ -136,12 +138,56 @@ class PostgreSQLNestedSourceArtifactRegistrarTests(unittest.TestCase):
 
         self.assertEqual(
             result,
-            NestedSourceArtifactResult(digest, len(evidence.raw_bytes), True),
+            NestedSourceArtifactResult(
+                digest, len(evidence.raw_bytes), evidence.downloaded_at, True
+            ),
         )
         self.assertEqual((connection.commits, connection.rollbacks), (1, 0))
         self.assertEqual(len(connection.executions), 3)
         self.assertIn("SELECT feed, report_date", connection.executions[2][0])
         self.assertEqual(connection.executions[2][1], (digest,))
+
+    def test_later_download_receipt_replays_without_replacing_first_seen_time(self) -> None:
+        stored_evidence = receipt()
+        replay_evidence = replace(
+            stored_evidence,
+            downloaded_at=stored_evidence.downloaded_at + timedelta(days=1),
+        )
+        digest = hashlib.sha256(replay_evidence.raw_bytes).hexdigest()
+        source_url = f"{OUTER_URL}#{DAILY_FILENAME}"
+        connection = FakeConnection(
+            (
+                ("nextday_soc", date(2025, 7, 1), OUTER_URL, None),
+                None,
+                (
+                    "nextday_soc",
+                    stored_evidence.report_date,
+                    source_url,
+                    stored_evidence.filename,
+                    len(stored_evidence.raw_bytes),
+                    stored_evidence.raw_bytes,
+                    stored_evidence.parent_artifact_sha256,
+                    stored_evidence.artifact_published_at,
+                    stored_evidence.downloaded_at,
+                    stored_evidence.publication_id,
+                ),
+            )
+        )
+
+        result = PostgreSQLNestedSourceArtifactRegistrar(connection).record(
+            replay_evidence
+        )
+
+        self.assertEqual(
+            result,
+            NestedSourceArtifactResult(
+                digest,
+                len(replay_evidence.raw_bytes),
+                stored_evidence.downloaded_at,
+                True,
+            ),
+        )
+        self.assertEqual((connection.commits, connection.rollbacks), (1, 0))
 
     def test_same_sha_with_changed_publication_metadata_fails_closed(self) -> None:
         evidence = receipt()

--- a/app/backend/tests/test_nextday_fcas_ingestion.py
+++ b/app/backend/tests/test_nextday_fcas_ingestion.py
@@ -1,0 +1,286 @@
+"""Tests for grouped FCAS persistence from retained Next Day observations."""
+
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+import unittest
+
+from psycopg.types.json import Jsonb
+
+from batterywatch_api.nextday_soc import (
+    NextDayFcasObservation,
+    parse_nextday_unit_solution_soc,
+)
+from batterywatch_api.nextday_fcas_ingestion import (
+    NextDayFcasConflictError,
+    NextDayFcasIngestionResult,
+    PostgreSQLNextDayFcasIngestor,
+)
+
+UTC = timezone.utc
+BACKEND = Path(__file__).resolve().parents[1]
+FIXTURE = BACKEND / "tests" / "fixtures" / "historical" / "nextday-unit-solution-soc-20260829-reduced.csv"
+ARTIFACT_SHA = "d7a2abdd2947ed4b222166b9f60e3a8052838190027dd9ce03cb291ba2d29bc4"
+
+
+class FakeCursor:
+    def __init__(self, connection) -> None:
+        self.connection = connection
+        self.query_kind = ""
+        self.parameters: tuple[Any, ...] = ()
+        self.rowcount = -1
+
+    def execute(self, statement, parameters) -> None:
+        self.parameters = tuple(parameters)
+        self.connection.executions.append((statement, self.parameters))
+        if "FROM historical_source_artifacts" in statement:
+            self.query_kind = "artifact"
+        elif "FROM raw_nextday_fcas_observations" in statement:
+            self.query_kind = "raw"
+        elif "FROM generator_fcas_5m" in statement:
+            self.query_kind = "effective"
+        else:
+            self.query_kind = ""
+
+    def executemany(self, statement, parameters) -> None:
+        rows = tuple(tuple(item) for item in parameters)
+        self.connection.bulk_executions.append((statement, rows))
+        if "raw_nextday_fcas_observations" in statement:
+            existing = {
+                (
+                    row[0],
+                    row[1],
+                    row[2],
+                    row[4],
+                    row[5],
+                    row[10],
+                    row[11],
+                )
+                for row in self.connection.raw_rows
+            }
+            for row in rows:
+                key = (
+                    row[0], row[1], row[2], row[4], row[5], row[10], row[11]
+                )
+                if key in existing:
+                    raise AssertionError("raw duplicate was not preflighted")
+                self.connection.raw_rows.append(row)
+                existing.add(key)
+            self.rowcount = len(rows)
+        elif "generator_fcas_5m" in statement:
+            applied = 0
+            for row in rows:
+                key = (row[0], row[1])
+                candidate_precedence = (
+                    row[6], row[10], row[9], row[4], row[11]
+                )
+                for index, stored in enumerate(self.connection.effective_rows):
+                    if (stored[0], stored[1]) != key:
+                        continue
+                    stored_precedence = (
+                        stored[6], stored[10], stored[9], stored[4], stored[11]
+                    )
+                    if candidate_precedence > stored_precedence:
+                        self.connection.effective_rows[index] = row
+                        applied += 1
+                    break
+                else:
+                    self.connection.effective_rows.append(row)
+                    applied += 1
+            self.rowcount = applied
+        else:
+            raise AssertionError("unexpected bulk statement")
+
+    def fetchone(self):
+        if self.query_kind == "artifact":
+            return self.connection.artifact_row
+        return None
+
+    def fetchall(self):
+        if self.query_kind == "raw":
+            artifact, ingestion, correction = self.parameters
+            return [
+                row
+                for row in self.connection.raw_rows
+                if row[0] == artifact
+                and row[10] == ingestion
+                and row[11] == correction
+            ]
+        if self.query_kind == "effective":
+            duids, start, end = self.parameters
+            return [
+                row
+                for row in self.connection.effective_rows
+                if row[0] in duids and start <= row[1] <= end
+            ]
+        return []
+
+    def close(self) -> None:
+        self.connection.closed_cursors += 1
+
+
+class FakeConnection:
+    def __init__(
+        self,
+        *,
+        artifact_row=("nextday_soc",),
+        raw_rows=(),
+        effective_rows=(),
+    ) -> None:
+        self.artifact_row = artifact_row
+        self.executions = []
+        self.bulk_executions = []
+        self.raw_rows = list(raw_rows)
+        self.effective_rows = list(effective_rows)
+        self.closed_cursors = 0
+        self.commits = self.rollbacks = 0
+
+    def cursor(self):
+        return FakeCursor(self)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+def observation():
+    return parse_nextday_unit_solution_soc(
+        FIXTURE.read_text(encoding="utf-8"),
+        duids=frozenset(("ADPBA1",)),
+        source_artifact_id=ARTIFACT_SHA,
+        downloaded_at=datetime(2026, 8, 30, tzinfo=UTC),
+        ingestion_version=8,
+        correction_version=2,
+    )[0]
+
+
+class PostgreSQLNextDayFcasIngestorTests(unittest.TestCase):
+    def test_one_observation_creates_one_grouped_raw_and_effective_record(self) -> None:
+        connection = FakeConnection()
+
+        result = PostgreSQLNextDayFcasIngestor(connection).ingest((observation(),))
+
+        self.assertEqual(
+            result,
+            NextDayFcasIngestionResult(1, 1, 0, 1, 1, 0, 10),
+        )
+        self.assertEqual(len(connection.bulk_executions), 2)
+        raw_sql, raw_rows = connection.bulk_executions[0]
+        effective_sql, effective_rows = connection.bulk_executions[1]
+        self.assertIn("INSERT INTO raw_nextday_fcas_observations", raw_sql)
+        self.assertIn("INSERT INTO generator_fcas_5m", effective_sql)
+        self.assertEqual(len(raw_rows), 1)
+        self.assertEqual(len(effective_rows), 1)
+        self.assertEqual(len(raw_rows[0][3].obj), 10)
+        self.assertEqual(len(effective_rows[0][2].obj), 10)
+        self.assertEqual(raw_rows[0][3].obj["raise_6s"]["target_mw"], 3.0)
+        self.assertEqual(effective_rows[0][2].obj, raw_rows[0][3].obj)
+        self.assertEqual((connection.commits, connection.rollbacks), (1, 0))
+
+    def test_exact_replay_is_a_noop(self) -> None:
+        source = observation()
+        connection = FakeConnection()
+        ingestor = PostgreSQLNextDayFcasIngestor(connection)
+        ingestor.ingest((source,))
+
+        result = ingestor.ingest((source,))
+
+        self.assertEqual(result.raw_inserted, 0)
+        self.assertEqual(result.raw_replayed, 1)
+        self.assertEqual(result.effective_applied, 0)
+        self.assertEqual(result.effective_replayed, 1)
+        self.assertEqual(len(connection.raw_rows), 1)
+        self.assertEqual(len(connection.effective_rows), 1)
+        self.assertEqual(
+            len([item for item in connection.bulk_executions if item[0].lstrip().startswith("INSERT")]),
+            2,
+        )
+
+    def test_equal_precedence_conflict_fails_closed(self) -> None:
+        source = observation()
+        connection = FakeConnection()
+        ingestor = PostgreSQLNextDayFcasIngestor(connection)
+        ingestor.ingest((source,))
+        changed_map = dict(connection.effective_rows[0][2].obj)
+        changed_map["raise_6s"] = dict(changed_map["raise_6s"])
+        changed_map["raise_6s"]["target_mw"] = 99.0
+        conflicting_effective = list(connection.effective_rows[0])
+        conflicting_effective[2] = Jsonb(changed_map)
+        connection.effective_rows[0] = tuple(conflicting_effective)
+        connection.bulk_executions = []
+        connection.commits = connection.rollbacks = 0
+
+        with self.assertRaisesRegex(NextDayFcasConflictError, "equal precedence"):
+            ingestor.ingest((source,))
+
+        self.assertEqual(connection.bulk_executions, [])
+        self.assertEqual((connection.commits, connection.rollbacks), (0, 1))
+
+    def test_conflicting_raw_replay_fails_closed(self) -> None:
+        source = observation()
+        connection = FakeConnection()
+        ingestor = PostgreSQLNextDayFcasIngestor(connection)
+        ingestor.ingest((source,))
+        conflicting = list(connection.raw_rows[0])
+        conflicting[3] = Jsonb({"raise_6s": {"target_mw": 99.0}})
+        connection.raw_rows[0] = tuple(conflicting)
+        connection.bulk_executions = []
+        connection.commits = connection.rollbacks = 0
+
+        with self.assertRaisesRegex(NextDayFcasConflictError, "stored raw"):
+            ingestor.ingest((source,))
+
+        self.assertEqual(connection.bulk_executions, [])
+        self.assertEqual((connection.commits, connection.rollbacks), (0, 1))
+
+    def test_newer_precedence_replaces_one_effective_group(self) -> None:
+        source = observation()
+        connection = FakeConnection()
+        ingestor = PostgreSQLNextDayFcasIngestor(connection)
+        ingestor.ingest((source,))
+        changed_services = dict(source.fcas.services)
+        changed_services["raise_6s"] = replace(
+            source.fcas.raise_6s,
+            target_mw=4.0,
+        )
+        newer = replace(
+            source,
+            correction_version=3,
+            fcas=NextDayFcasObservation(changed_services),
+        )
+
+        result = ingestor.ingest((newer,))
+
+        self.assertEqual(result.raw_inserted, 1)
+        self.assertEqual(result.effective_candidates, 1)
+        self.assertEqual(result.effective_applied, 1)
+        self.assertEqual(result.effective_replayed, 0)
+        self.assertEqual(len(connection.raw_rows), 2)
+        self.assertEqual(len(connection.effective_rows), 1)
+        self.assertEqual(connection.effective_rows[0][10], 3)
+        self.assertEqual(
+            connection.effective_rows[0][2].obj["raise_6s"]["target_mw"],
+            4.0,
+        )
+
+    def test_requires_existing_nextday_soc_artifact_registration(self) -> None:
+        connection = FakeConnection(artifact_row=("dispatch_scada",))
+
+        with self.assertRaisesRegex(ValueError, "nextday_soc"):
+            PostgreSQLNextDayFcasIngestor(connection).ingest((observation(),))
+
+        self.assertEqual(connection.bulk_executions, [])
+        self.assertEqual((connection.commits, connection.rollbacks), (0, 1))
+        self.assertFalse(
+            any(
+                "INSERT INTO historical_source_artifacts" in statement
+                for statement, _ in connection.executions
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/backend/tests/test_nextday_soc.py
+++ b/app/backend/tests/test_nextday_soc.py
@@ -1,11 +1,20 @@
 """Tests for authoritative Next Day UnitSolution SOC parsing."""
 
+import csv
 from datetime import datetime, timezone
+from io import StringIO
 from pathlib import Path
 from typing import Any
 import unittest
 
-from batterywatch_api.nextday_soc import NextDaySocParseError, parse_nextday_unit_solution_soc
+from batterywatch_api import nextday_soc as nextday_soc_module
+from batterywatch_api.nextday_soc import (
+    FCAS_SERVICES,
+    NextDayFcasObservation,
+    NextDaySocObservation,
+    NextDaySocParseError,
+    parse_nextday_unit_solution_soc,
+)
 
 UTC = timezone.utc
 FIXTURE = Path(__file__).parent / "fixtures" / "historical" / "nextday-unit-solution-soc-20260829-reduced.csv"
@@ -32,6 +41,30 @@ class NextDaySocParserTests(unittest.TestCase):
             correction_version=2,
         )
 
+    def mutate_row(self, payload: str, **changes: str) -> str:
+        rows = list(csv.reader(StringIO(payload)))
+        header = rows[1]
+        duid_index = header.index("DUID")
+        row = next(
+            row for row in rows[2:]
+            if len(row) > duid_index and row[duid_index] == "ADPBA1"
+        )
+        for column, value in changes.items():
+            row[header.index(column)] = value
+        output = StringIO(newline="")
+        csv.writer(output, lineterminator="\n").writerows(rows)
+        return output.getvalue()
+
+    def without_columns(self, payload: str, *columns: str) -> str:
+        rows = list(csv.reader(StringIO(payload)))
+        header = rows[1]
+        indexes = {header.index(column) for column in columns}
+        for row in rows[:2] + [row for row in rows[2:] if row and row[0] == "D"]:
+            row[:] = [value for index, value in enumerate(row) if index not in indexes]
+        output = StringIO(newline="")
+        csv.writer(output, lineterminator="\n").writerows(rows)
+        return output.getvalue()
+
     def test_parses_real_derived_mwh_null_and_publication_latency(self) -> None:
         observations = self.parse()
 
@@ -57,6 +90,184 @@ class NextDaySocParserTests(unittest.TestCase):
             sorted((item.duid, item.interval_start) for item in observations),
         )
 
+    def test_v6_observations_include_all_canonical_fcas_services(self) -> None:
+        observations = self.parse()
+
+        self.assertEqual(
+            tuple(observations[0].fcas.services),
+            (
+                "raise_1s",
+                "lower_1s",
+                "raise_6s",
+                "lower_6s",
+                "raise_60s",
+                "lower_60s",
+                "raise_5m",
+                "lower_5m",
+                "raise_reg",
+                "lower_reg",
+            ),
+        )
+
+    def test_retains_positive_and_enabled_zero_fcas_values(self) -> None:
+        payload = self.mutate_row(self.payload, RAISE1SECFLAGS="1")
+        observations = self.parse(payload)
+        first = observations[0]
+        positive = first.fcas.raise_6s
+        self.assertEqual(positive.target_mw, 3.0)
+        self.assertEqual(positive.enablement_status, 1)
+        self.assertEqual(positive.actual_availability_mw, 3.0)
+        self.assertTrue(positive.enabled)
+        self.assertTrue(positive.cleared)
+        self.assertTrue(positive.participating)
+
+        enabled_zero = first.fcas.raise_1s
+        self.assertEqual(enabled_zero.target_mw, 0.0)
+        self.assertEqual(enabled_zero.enablement_status, 1)
+        self.assertEqual(enabled_zero.actual_availability_mw, 0.0)
+        self.assertTrue(enabled_zero.enabled)
+        self.assertFalse(enabled_zero.cleared)
+        self.assertFalse(enabled_zero.participating)
+        self.assertEqual(first.fcas.reported_service_count, 10)
+
+    def test_fcas_model_keeps_one_canonical_surface(self) -> None:
+        service = self.parse()[0].fcas.raise_6s
+
+        self.assertTrue(service.reported)
+        self.assertIsNone(service.response_evidence)
+        for redundant in (
+            "is_enabled",
+            "is_trapped",
+            "is_stranded",
+            "is_cleared",
+            "is_participating",
+            "response_verified",
+            "response_verification",
+        ):
+            with self.subTest(redundant=redundant):
+                self.assertFalse(hasattr(service, redundant))
+        for alias in (
+            "NextDayFcasService",
+            "FcasServiceObservation",
+            "FcasObservation",
+        ):
+            with self.subTest(alias=alias):
+                self.assertFalse(hasattr(nextday_soc_module, alias))
+
+    def test_derives_trapped_stranded_epsilon_and_unknown_response(self) -> None:
+        payload = self.mutate_row(
+            self.payload,
+            RAISE6SECFLAGS="3",
+            LOWER6SECFLAGS="4",
+            RAISE60SEC="0.000001",
+        )
+        first = self.parse(payload)[0]
+        trapped = first.fcas.raise_6s
+        self.assertTrue(trapped.enabled)
+        self.assertTrue(trapped.trapped)
+        self.assertTrue(trapped.participating)
+        stranded = first.fcas.lower_6s
+        self.assertTrue(stranded.stranded)
+        self.assertFalse(stranded.enabled)
+        self.assertTrue(stranded.cleared)
+        self.assertFalse(stranded.participating)
+        epsilon = first.fcas.raise_60s
+        self.assertFalse(epsilon.cleared)
+        self.assertFalse(epsilon.participating)
+        self.assertIsNone(epsilon.response_evidence)
+
+    def test_missing_fcas_columns_are_null_without_shifting_other_services(self) -> None:
+        payload = self.without_columns(
+            self.payload,
+            "RAISE1SEC",
+            "RAISE1SECFLAGS",
+            "RAISE1SECACTUALAVAILABILITY",
+        )
+        first = self.parse(payload)[0]
+        self.assertEqual(tuple(first.fcas.services), FCAS_SERVICES)
+        self.assertEqual(
+            first.fcas.raise_1s,
+            type(first.fcas.raise_1s)(),
+        )
+        self.assertEqual(first.fcas.raise_6s.target_mw, 3.0)
+
+    def test_all_absent_fcas_columns_remain_null_in_fixed_service_map(self) -> None:
+        payload = self.without_columns(
+            self.payload,
+            "RAISE1SEC",
+            "RAISE1SECFLAGS",
+            "RAISE1SECACTUALAVAILABILITY",
+            "LOWER1SEC",
+            "LOWER1SECFLAGS",
+            "LOWER1SECACTUALAVAILABILITY",
+            "RAISE6SEC",
+            "RAISE6SECFLAGS",
+            "RAISE6SECACTUALAVAILABILITY",
+            "LOWER6SEC",
+            "LOWER6SECFLAGS",
+            "LOWER6SECACTUALAVAILABILITY",
+            "RAISE60SEC",
+            "RAISE60SECFLAGS",
+            "RAISE60SECACTUALAVAILABILITY",
+            "LOWER60SEC",
+            "LOWER60SECFLAGS",
+            "LOWER60SECACTUALAVAILABILITY",
+            "RAISE5MIN",
+            "RAISE5MINFLAGS",
+            "RAISE5MINACTUALAVAILABILITY",
+            "LOWER5MIN",
+            "LOWER5MINFLAGS",
+            "LOWER5MINACTUALAVAILABILITY",
+            "RAISEREG",
+            "RAISEREGFLAGS",
+            "RAISEREGACTUALAVAILABILITY",
+            "LOWERREG",
+            "LOWERREGFLAGS",
+            "LOWERREGACTUALAVAILABILITY",
+        )
+        first = self.parse(payload)[0]
+
+        self.assertEqual(tuple(first.fcas.services), FCAS_SERVICES)
+        self.assertEqual(first.fcas.reported_service_count, 0)
+        self.assertTrue(
+            all(service == type(service)() for service in first.fcas.services.values())
+        )
+
+    def test_soc_constructor_defaults_to_empty_fcas_group(self) -> None:
+        observation = NextDaySocObservation(
+            "ADPBA1",
+            datetime(2026, 8, 28, 18, 5, tzinfo=UTC),
+            1.0,
+            0,
+            1,
+            "20260829001",
+            datetime(2026, 8, 28, 18, tzinfo=UTC),
+            "a" * 64,
+            datetime(2026, 8, 29, 18, 10, tzinfo=UTC),
+            datetime(2026, 8, 30, tzinfo=UTC),
+            1,
+            0,
+        )
+
+        self.assertEqual(observation.fcas, NextDayFcasObservation.empty())
+        self.assertEqual(observation.fcas.reported_service_count, 0)
+
+    def test_invalid_fcas_numeric_and_status_values_fail_closed(self) -> None:
+        cases = (
+            {"RAISE6SEC": "-1"},
+            {"RAISE6SECACTUALAVAILABILITY": "-1"},
+            {"RAISE6SECACTUALAVAILABILITY": "NaN"},
+            {"RAISE6SECACTUALAVAILABILITY": "Infinity"},
+            {"RAISE6SECFLAGS": "5"},
+            {"RAISE6SECFLAGS": "1.5"},
+            {"RAISE6SECFLAGS": "malformed"},
+            {"RAISE6SECFLAGS": "1" * 5000},
+        )
+        for changes in cases:
+            with self.subTest(changes=changes):
+                with self.assertRaises(NextDaySocParseError):
+                    self.parse(self.mutate_row(self.payload, **changes))
+
     def test_filters_to_reviewed_duids_without_inventing_missing_rows(self) -> None:
         observations = self.parse(duids=frozenset(("ADPBA1",)))
         self.assertEqual(len(observations), 2)
@@ -79,6 +290,9 @@ class NextDaySocParserTests(unittest.TestCase):
         observation = observations[0]
         self.assertEqual(observation.duid, "ADPBA1")
         self.assertEqual(observation.soc_mwh, 0.0)
+        self.assertEqual(tuple(observation.fcas.services), FCAS_SERVICES)
+        self.assertEqual(observation.fcas.raise_6s.target_mw, 0.0)
+        self.assertEqual(observation.fcas.raise_6s.actual_availability_mw, 0.0)
         self.assertEqual(
             observation.interval_start,
             datetime(2025, 6, 30, 18, 5, tzinfo=UTC),

--- a/app/deploy/migrate.sh
+++ b/app/deploy/migrate.sh
@@ -39,9 +39,11 @@ psql --dbname="$database_url" --no-psqlrc --set=ON_ERROR_STOP=1 \
   --file="$app_dir/migrations/008_authoritative_soc.sql"
 psql --dbname="$database_url" --no-psqlrc --set=ON_ERROR_STOP=1 \
   --file="$app_dir/migrations/009_allow_archive_urls.sql"
+psql --dbname="$database_url" --no-psqlrc --set=ON_ERROR_STOP=1 \
+  --file="$app_dir/migrations/010_nextday_fcas.sql"
 psql --dbname="$database_url" --no-psqlrc --set=ON_ERROR_STOP=1 --tuples-only --no-align \
   <<'SQL'
-SELECT count(*) = 13
+SELECT count(*) = 15
 FROM information_schema.tables
 WHERE table_schema = 'public'
   AND table_name IN (
@@ -51,7 +53,8 @@ WHERE table_schema = 'public'
     'historical_backfill_runs',
     'historical_backfill_items', 'historical_backfill_events',
     'historical_source_artifacts', 'historical_backfill_item_artifacts',
-    'raw_nextday_soc_observations'
+    'raw_nextday_soc_observations', 'raw_nextday_fcas_observations',
+    'generator_fcas_5m'
   );
 SQL
 unset database_url

--- a/app/deploy/migrate.sh
+++ b/app/deploy/migrate.sh
@@ -41,6 +41,8 @@ psql --dbname="$database_url" --no-psqlrc --set=ON_ERROR_STOP=1 \
   --file="$app_dir/migrations/009_allow_archive_urls.sql"
 psql --dbname="$database_url" --no-psqlrc --set=ON_ERROR_STOP=1 \
   --file="$app_dir/migrations/010_nextday_fcas.sql"
+psql -d "$database_url" --no-psqlrc --set=ON_ERROR_STOP=1 \
+  --file="$app_dir/migrations/011_fcas_validator_compatibility.sql"
 psql --dbname="$database_url" --no-psqlrc --set=ON_ERROR_STOP=1 --tuples-only --no-align \
   <<'SQL'
 SELECT count(*) = 15

--- a/app/frontend/src/main.tsx
+++ b/app/frontend/src/main.tsx
@@ -15,6 +15,11 @@ import {
 type Generator = { duid: string; site_name: string; region: string };
 type Point = { timestamp: string; power_mw: number | null; price_aud_per_mwh: number | null; net_energy_value_aud: number | null };
 type Series = { generator: Generator; points: Point[]; summary: { exported_energy_mwh: number; imported_energy_mwh: number; net_energy_value_aud: number }; coverage: { power_coverage_percent: number; price_coverage_percent: number; soc_coverage_percent: number }; estimate: { label: string; disclaimer: string } };
+type FcasServiceName = "raise_1s" | "lower_1s" | "raise_6s" | "lower_6s" | "raise_60s" | "lower_60s" | "raise_5m" | "lower_5m" | "raise_reg" | "lower_reg";
+type FcasServicePoint = { target_mw: number | null; enablement_status: number | null; actual_availability_mw: number | null; enabled: boolean; trapped: boolean; stranded: boolean; cleared: boolean; participating: boolean; response_verified: false };
+type FcasPoint = { timestamp: string; services: Record<FcasServiceName, FcasServicePoint> };
+type FcasSummary = { reported_intervals: number; enabled_intervals: number; cleared_intervals: number; participating_intervals: number; trapped_intervals: number; stranded_intervals: number; max_target_mw: number | null; max_actual_availability_mw: number | null };
+type Fcas = { selected_services: FcasServiceName[]; points: FcasPoint[]; coverage: { expected_intervals: number; observed_intervals: number; missing_intervals: number; coverage_percent: number }; latest_finalized: { interval_start: string; report_timestamp: string; downloaded_at: string; source_artifact_sha256: string; dispatch_interval: string; intervention: number; run_number: number } | null; publication_state: "available" | "partial" | "not_yet_public" | "no_data"; service_summaries: Partial<Record<FcasServiceName, FcasSummary>> };
 type RangeOption = { value: RangePreset; label: string };
 type TooltipEntry = { name: string; axisValue?: string | number; seriesName?: string; value: unknown; marker?: string };
 type DataZoomEvent = { start?: number; end?: number; startValue?: unknown; endValue?: unknown; batch?: DataZoomEvent[] };
@@ -29,7 +34,16 @@ function formatTimestamp(value: unknown) {
 function isAbortError(error: unknown) {
   return (error instanceof DOMException && error.name === "AbortError") || (error instanceof Error && error.name === "AbortError");
 }
-
+function fcasServiceLabel(service: FcasServiceName) {
+  const labels: Record<FcasServiceName, string> = { raise_1s: "Raise 1-second", lower_1s: "Lower 1-second", raise_6s: "Raise 6-second", lower_6s: "Lower 6-second", raise_60s: "Raise 60-second", lower_60s: "Lower 60-second", raise_5m: "Raise 5-minute", lower_5m: "Lower 5-minute", raise_reg: "Raise regulation", lower_reg: "Lower regulation" };
+  return labels[service];
+}
+function fcasPublicationLabel(state: Fcas["publication_state"]) {
+  if (state === "not_yet_public") return "not yet public";
+  if (state === "no_data") return "no data";
+  if (state === "partial") return "partial coverage";
+  return "available";
+}
 const RANGE_OPTIONS: RangeOption[] = [
   { value: "24h", label: "24h" },
   { value: "7d", label: "7d" },
@@ -48,6 +62,8 @@ function App() {
   const [generators, setGenerators] = useState<Generator[]>([]);
   const [selected, setSelected] = useState("");
   const [series, setSeries] = useState<Series | null>(null);
+  const [fcas, setFcas] = useState<Fcas | null>(null);
+  const [fcasError, setFcasError] = useState("");
   const [range, setRange] = useState<HistoryRange>(() => latestRange("24h"));
   const [visibleNetValue, setVisibleNetValue] = useState<number | null>(null);
   const [showPrice, setShowPrice] = useState(() => !window.matchMedia("(max-width: 780px)").matches);
@@ -55,6 +71,7 @@ function App() {
   const [customStart, setCustomStart] = useState("");
   const [customEnd, setCustomEnd] = useState("");
   const chartRef = useRef<HTMLDivElement>(null);
+  const fcasChartRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -88,6 +105,21 @@ function App() {
       .then((body) => { if (!obsolete) setSeries(body); })
       .catch((reason: unknown) => {
         if (!obsolete && !isAbortError(reason)) setError(`Unable to load the selected ${rangeLabel(range.preset)} range.`);
+      });
+    return () => { obsolete = true; controller.abort(); };
+  }, [selected, range]);
+  useEffect(() => {
+    if (!selected) return;
+    const controller = new AbortController();
+    let obsolete = false;
+    setFcas(null);
+    setFcasError("");
+    const query = new URLSearchParams({ generator: selected, start: range.start, end: range.end });
+    fetch(`/api/fcas?${query.toString()}`, { signal: controller.signal })
+      .then(async (r) => { if (!r.ok) throw new Error(); return r.json(); })
+      .then((body) => { if (!obsolete) setFcas(body); })
+      .catch((reason: unknown) => {
+        if (!obsolete && !isAbortError(reason)) setFcasError(`Unable to load FCAS data for the selected ${rangeLabel(range.preset)} range.`);
       });
     return () => { obsolete = true; controller.abort(); };
   }, [selected, range]);
@@ -233,6 +265,39 @@ function App() {
     mobileQuery.addEventListener("change", mediaChange);
     return () => { chart.off("datazoom", handleDataZoom); window.removeEventListener("resize", resize); mobileQuery.removeEventListener("change", mediaChange); chart.dispose(); };
   }, [series, showPrice, range.preset]);
+  useEffect(() => {
+    if (!fcasChartRef.current || !fcas || fcas.points.length === 0) return;
+    const chart = echarts.init(fcasChartRef.current);
+    const mobileQuery = window.matchMedia("(max-width: 780px)");
+    const labels = fcas.selected_services.map(fcasServiceLabel);
+    const applyResponsiveLayout = () => {
+      chart.setOption({ grid: { left: mobileQuery.matches ? 52 : 64, right: 18, containLabel: true } });
+    };
+    chart.setOption({
+      animation: false,
+      aria: { enabled: true },
+      tooltip: { trigger: "axis" },
+      legend: { top: 8, textStyle: { color: "#ffffff" }, data: labels },
+      grid: { left: 64, right: 18, top: 48, bottom: 58 },
+      xAxis: { type: "time", axisLabel: { color: "#ffffff", fontSize: 11 } },
+      yAxis: { type: "value", name: "Target MW", axisLabel: { color: "#ffffff", fontSize: 11 }, nameTextStyle: { color: "#ffffff" }, splitLine: { lineStyle: { color: "rgba(255, 255, 255, 0.1)" } } },
+      series: fcas.selected_services.map((service) => ({
+        name: fcasServiceLabel(service),
+        type: "line",
+        showSymbol: range.preset === "24h",
+        symbol: "circle",
+        symbolSize: 6,
+        connectNulls: false,
+        data: fcas.points.map((point) => [point.timestamp, point.services[service]?.target_mw ?? null]),
+      })),
+    });
+    applyResponsiveLayout();
+    const resize = () => { applyResponsiveLayout(); chart.resize(); };
+    const mediaChange = () => resize();
+    window.addEventListener("resize", resize);
+    mobileQuery.addEventListener("change", mediaChange);
+    return () => { window.removeEventListener("resize", resize); mobileQuery.removeEventListener("change", mediaChange); chart.dispose(); };
+  }, [fcas, range.preset]);
 
   return <main>
     <header><div><p className="eyebrow">STANDALONE BATTERY ANALYTICS</p><h1>BatteryWatch</h1><p className="lede">Five-minute battery power, regional price overlays, and transparent energy estimates.</p></div><label>Generator<select value={selected} onChange={(event) => setSelected(event.target.value)}>{generators.map((g) => <option key={g.duid} value={g.duid}>{g.site_name} · {g.duid} · {g.region}</option>)}</select></label></header>
@@ -260,6 +325,19 @@ function App() {
       <section className="panel"><div className="panel-heading"><div><h2>{series.generator.site_name}</h2><p>{series.points.length} five-minute intervals in the selected {rangeLabel(range.preset)} window · zoom and pan enabled</p></div><div className="panel-actions"><label className="chart-toggle"><input type="checkbox" checked={showPrice} onChange={(event) => setShowPrice(event.target.checked)} /> Show price data</label><span className="badge">{series.estimate.label}</span></div></div><div ref={chartRef} className="chart" /></section>
       <aside className="notice"><strong>Estimated value — not actual profit.</strong> {series.estimate.disclaimer}</aside>
     </>}
+    {selected && <section className="panel fcas-panel" aria-labelledby="fcas-heading">
+      <div className="panel-heading"><div><h2 id="fcas-heading">FCAS dispatch targets</h2><p>Selected {rangeLabel(range.preset)} window · grouped five-minute finalized service observations</p></div>{fcas && <span className={`badge fcas-state fcas-state-${fcas.publication_state}`} role="status" aria-live="polite">{fcasPublicationLabel(fcas.publication_state)}</span>}</div>
+      {fcasError && <div className="error fcas-error" role="alert">{fcasError}</div>}
+      {!fcas && !fcasError && <p className="loading" role="status" aria-live="polite">Loading FCAS dispatch targets for the selected range…</p>}
+      {fcas && <>
+        <p className="fcas-disclaimer"><strong>AEMO finalized dispatch target — not verified physical response</strong></p>
+        <p className="fcas-coverage" role="status" aria-live="polite">{fcas.coverage.observed_intervals} of {fcas.coverage.expected_intervals} five-minute intervals reported · {fcas.coverage.coverage_percent.toFixed(0)}% coverage{fcas.latest_finalized ? ` · latest finalized ${formatTimestamp(fcas.latest_finalized.interval_start)}` : ""}</p>
+        {fcas.points.length > 0 && <div ref={fcasChartRef} className="fcas-chart" role="img" aria-label="FCAS target MW time series" />}
+        <div className="fcas-summary-grid">
+          {fcas.selected_services.map((service) => { const summary = fcas.service_summaries[service]; return <article key={service}><h3>{fcasServiceLabel(service)}</h3>{summary ? <dl><div><dt>Reported</dt><dd>{summary.reported_intervals}</dd></div><div><dt>Enabled</dt><dd>{summary.enabled_intervals}</dd></div><div><dt>Cleared</dt><dd>{summary.cleared_intervals}</dd></div><div><dt>Participating</dt><dd>{summary.participating_intervals}</dd></div><div><dt>Trapped / stranded</dt><dd>{summary.trapped_intervals} / {summary.stranded_intervals}</dd></div><div><dt>Max target</dt><dd>{summary.max_target_mw == null ? "—" : `${summary.max_target_mw.toFixed(3)} MW`}</dd></div><div><dt>Max availability</dt><dd>{summary.max_actual_availability_mw == null ? "—" : `${summary.max_actual_availability_mw.toFixed(3)} MW`}</dd></div></dl> : <p>Summary unavailable.</p>}</article>; })}
+        </div>
+      </>}
+    </section>}
   </main>;
 }
 

--- a/app/frontend/src/styles.css
+++ b/app/frontend/src/styles.css
@@ -25,6 +25,21 @@ select { display: block; width: 100%; margin-top: 8px; background: #0d1d31; colo
 .cards strong { color: #f8fafc; display: block; font-size: 22px; margin-top: 9px; }
 .cards small { margin-top: 3px; }
 .panel { display: flex; flex: 1 1 auto; flex-direction: column; min-height: 560px; padding: 20px 0 8px; }
+.fcas-panel { min-height: 0; margin-top: 18px; padding-bottom: 20px; }
+.fcas-panel .panel-heading { margin-bottom: 8px; }
+.fcas-state { text-transform: lowercase; }
+.fcas-disclaimer, .fcas-coverage { margin: 10px 20px; color: #cbd5e1; font-size: 13px; line-height: 1.5; }
+.fcas-disclaimer { color: #fbbf24; }
+.fcas-coverage { color: #94a3b8; }
+.fcas-error { margin: 10px 20px; }
+.fcas-chart { width: 100%; min-height: 320px; height: 320px; }
+.fcas-summary-grid { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 10px; margin: 10px 20px 0; }
+.fcas-summary-grid article { background: #102238; border: 1px solid #1e3854; border-radius: 9px; padding: 12px; min-width: 0; }
+.fcas-summary-grid h3 { color: #f8fafc; font-size: 13px; line-height: 1.3; margin: 0 0 10px; }
+.fcas-summary-grid dl { margin: 0; }
+.fcas-summary-grid dl div { display: flex; justify-content: space-between; gap: 8px; border-top: 1px solid rgba(148, 163, 184, 0.16); padding: 5px 0; }
+.fcas-summary-grid dt { color: #94a3b8; font-size: 11px; }
+.fcas-summary-grid dd { color: #f8fafc; font-size: 11px; font-weight: 700; margin: 0; text-align: right; }
 .panel-heading { display: flex; justify-content: space-between; align-items: start; padding: 0 20px; gap: 16px; }
 .panel-actions { display: flex; align-items: center; gap: 12px; }
 .chart-toggle { min-width: auto; display: flex; align-items: center; gap: 6px; color: #cbd5e1; font-size: 12px; font-weight: 600; white-space: nowrap; }
@@ -37,7 +52,7 @@ h2 { margin: 0; font-size: 18px; }
 .notice strong { color: #fbbf24; }
 .error { margin: 24px 0; background: #35161b; border: 1px solid #a33a4b; color: #fecdd3; border-radius: 8px; padding: 14px; }
 .loading { color: #94a3b8; padding: 60px 0; text-align: center; }
-@media (max-width: 1100px) { .cards { grid-template-columns: repeat(3, 1fr); } }
+@media (max-width: 1100px) { .cards { grid-template-columns: repeat(3, 1fr); } .fcas-summary-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
 @media (max-width: 780px) {
   main { padding: 24px 0 40px; }
   header { display: block; padding: 0 16px 28px; }
@@ -48,6 +63,10 @@ h2 { margin: 0; font-size: 18px; }
   .selected-window { margin-left: 16px; margin-right: 16px; }
   .cards { grid-template-columns: repeat(2, 1fr); margin-left: 16px; margin-right: 16px; }
   .panel { min-height: 470px; border-left: 0; border-right: 0; border-radius: 0; }
+  .fcas-panel { min-height: 0; padding-top: 18px; }
+  .fcas-summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); margin-left: 16px; margin-right: 16px; }
+  .fcas-disclaimer, .fcas-coverage { margin-left: 16px; margin-right: 16px; }
+  .fcas-error { margin-left: 16px; margin-right: 16px; }
   .panel-heading { display: block; padding: 0 16px; }
   .panel-actions { display: flex; justify-content: space-between; flex-wrap: wrap; margin-top: 14px; }
   .badge { display: inline-block; }

--- a/app/frontend/tests/fcas-contract.test.mjs
+++ b/app/frontend/tests/fcas-contract.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const source = await readFile(new URL("../src/main.tsx", import.meta.url), "utf8");
+const styles = await readFile(new URL("../src/styles.css", import.meta.url), "utf8");
+
+test("FCAS panel uses the exact physical-response disclaimer", () => {
+  assert.match(
+    source,
+    /AEMO finalized dispatch target — not verified physical response/,
+  );
+});
+
+test("FCAS requests use selected bounds and abort obsolete responses", () => {
+  assert.match(source, /\/api\/fcas/);
+  assert.match(source, /new AbortController\(\)/);
+  assert.match(source, /start: range\.start/);
+  assert.match(source, /end: range\.end/);
+  assert.match(source, /signal/);
+  assert.match(source, /let obsolete = false/);
+  assert.match(source, /if \(!obsolete\)/);
+});
+
+test("FCAS summaries expose enablement counts and availability maxima", () => {
+  assert.match(source, /<dt>Enabled<\/dt>/);
+  assert.match(source, /max_actual_availability_mw/);
+});
+
+test("FCAS panel exposes publication status and remains usable on mobile", () => {
+  assert.match(source, /not yet public/);
+  assert.doesNotMatch(source, /inactive/);
+  assert.match(source, /role="status"/);
+  assert.match(styles, /@media \(max-width: 780px\)[\s\S]*?\.fcas-panel/);
+});

--- a/app/migrations/010_nextday_fcas.sql
+++ b/app/migrations/010_nextday_fcas.sql
@@ -1,0 +1,166 @@
+-- Retain grouped FCAS evidence projected from the already-registered Next Day
+-- UnitSolution bytes.  The map is deliberately one JSONB object per
+-- DUID/interval, not one physical row per service.  As with 008, these tables
+-- are PostgreSQL/Timescale-ready; operational hypertable conversion remains a
+-- separately reviewed deployment concern.
+
+BEGIN;
+
+-- Compare JSONB numbers as JSONB instead of casting arbitrary JSON text, so
+-- validation cannot throw on an oversized or non-finite numeric token.  The
+-- explicit special-value and type checks keep the fixed service-map contract
+-- in the database while rejecting unknown status codes.
+CREATE OR REPLACE FUNCTION nextday_fcas_service_jsonb_valid(value JSONB)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+IMMUTABLE
+AS $function$
+DECLARE
+    target_type TEXT;
+    status_type TEXT;
+    actual_type TEXT;
+BEGIN
+    IF value IS NULL OR jsonb_typeof(value) <> 'object' THEN
+        RETURN FALSE;
+    END IF;
+    IF jsonb_object_length(value) <> 3
+       OR NOT value ?& ARRAY[
+           'target_mw', 'enablement_status', 'actual_availability_mw'
+       ] THEN
+        RETURN FALSE;
+    END IF;
+
+    target_type := jsonb_typeof(value -> 'target_mw');
+    status_type := jsonb_typeof(value -> 'enablement_status');
+    actual_type := jsonb_typeof(value -> 'actual_availability_mw');
+    IF target_type NOT IN ('null', 'number')
+       OR status_type NOT IN ('null', 'number')
+       OR actual_type NOT IN ('null', 'number') THEN
+        RETURN FALSE;
+    END IF;
+
+    IF target_type = 'number' AND (
+        (value -> 'target_mw') < '0'::jsonb
+        OR (value ->> 'target_mw') IN ('NaN', 'Infinity', '-Infinity')
+    ) THEN
+        RETURN FALSE;
+    END IF;
+    IF actual_type = 'number' AND (
+        (value -> 'actual_availability_mw') < '0'::jsonb
+        OR (value ->> 'actual_availability_mw') IN ('NaN', 'Infinity', '-Infinity')
+    ) THEN
+        RETURN FALSE;
+    END IF;
+    IF status_type = 'number'
+       AND (value ->> 'enablement_status') NOT IN ('0', '1', '2', '3', '4') THEN
+        RETURN FALSE;
+    END IF;
+    RETURN TRUE;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION nextday_fcas_map_jsonb_valid(value JSONB)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+IMMUTABLE
+AS $function$
+DECLARE
+    service_name TEXT;
+BEGIN
+    IF value IS NULL OR jsonb_typeof(value) <> 'object' THEN
+        RETURN FALSE;
+    END IF;
+    IF jsonb_object_length(value) <> 10
+       OR NOT value ?& ARRAY[
+           'raise_1s', 'lower_1s', 'raise_6s', 'lower_6s',
+           'raise_60s', 'lower_60s', 'raise_5m', 'lower_5m',
+           'raise_reg', 'lower_reg'
+       ] THEN
+        RETURN FALSE;
+    END IF;
+    FOREACH service_name IN ARRAY ARRAY[
+        'raise_1s', 'lower_1s', 'raise_6s', 'lower_6s',
+        'raise_60s', 'lower_60s', 'raise_5m', 'lower_5m',
+        'raise_reg', 'lower_reg'
+    ] LOOP
+        IF NOT nextday_fcas_service_jsonb_valid(value -> service_name) THEN
+            RETURN FALSE;
+        END IF;
+    END LOOP;
+    RETURN TRUE;
+END
+$function$;
+
+CREATE TABLE IF NOT EXISTS raw_nextday_fcas_observations (
+    artifact_sha256 TEXT NOT NULL
+        REFERENCES historical_source_artifacts (artifact_sha256) ON DELETE RESTRICT,
+    generator_id TEXT NOT NULL
+        REFERENCES generators (generator_id) ON DELETE RESTRICT,
+    interval_start TIMESTAMPTZ NOT NULL,
+    fcas_services JSONB NOT NULL
+        CHECK (nextday_fcas_map_jsonb_valid(fcas_services)),
+    intervention SMALLINT NOT NULL CHECK (intervention IN (0, 1)),
+    run_number INTEGER NOT NULL CHECK (run_number > 0),
+    dispatch_interval TEXT NOT NULL CHECK (dispatch_interval ~ '^[0-9]{11}$'),
+    last_changed TIMESTAMPTZ NOT NULL,
+    report_timestamp TIMESTAMPTZ NOT NULL,
+    downloaded_at TIMESTAMPTZ NOT NULL,
+    ingestion_version BIGINT NOT NULL CHECK (ingestion_version >= 0),
+    correction_version BIGINT NOT NULL CHECK (correction_version >= 0),
+    stored_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (
+        artifact_sha256,
+        generator_id,
+        interval_start,
+        intervention,
+        run_number,
+        ingestion_version,
+        correction_version
+    ),
+    CHECK (date_trunc('minute', interval_start) = interval_start),
+    CHECK (EXTRACT(MINUTE FROM interval_start)::INTEGER % 5 = 0),
+    CHECK (last_changed <= report_timestamp),
+    CHECK (report_timestamp <= downloaded_at)
+);
+
+CREATE INDEX IF NOT EXISTS raw_nextday_fcas_observations_artifact_time_idx
+    ON raw_nextday_fcas_observations (artifact_sha256, interval_start ASC);
+CREATE INDEX IF NOT EXISTS raw_nextday_fcas_observations_generator_time_idx
+    ON raw_nextday_fcas_observations (generator_id, interval_start DESC);
+
+CREATE TABLE IF NOT EXISTS generator_fcas_5m (
+    generator_id TEXT NOT NULL
+        REFERENCES generators (generator_id) ON DELETE RESTRICT,
+    interval_start TIMESTAMPTZ NOT NULL,
+    fcas_services JSONB NOT NULL
+        CHECK (nextday_fcas_map_jsonb_valid(fcas_services)),
+    last_changed TIMESTAMPTZ NOT NULL,
+    report_timestamp TIMESTAMPTZ NOT NULL,
+    downloaded_at TIMESTAMPTZ NOT NULL,
+    intervention SMALLINT NOT NULL CHECK (intervention IN (0, 1)),
+    run_number INTEGER NOT NULL CHECK (run_number > 0),
+    dispatch_interval TEXT NOT NULL CHECK (dispatch_interval ~ '^[0-9]{11}$'),
+    ingestion_version BIGINT NOT NULL CHECK (ingestion_version >= 0),
+    correction_version BIGINT NOT NULL CHECK (correction_version >= 0),
+    source_artifact_sha256 TEXT NOT NULL
+        REFERENCES historical_source_artifacts (artifact_sha256) ON DELETE RESTRICT,
+    PRIMARY KEY (generator_id, interval_start),
+    UNIQUE (
+        generator_id,
+        interval_start,
+        source_artifact_sha256,
+        ingestion_version,
+        correction_version
+    ),
+    CHECK (date_trunc('minute', interval_start) = interval_start),
+    CHECK (EXTRACT(MINUTE FROM interval_start)::INTEGER % 5 = 0),
+    CHECK (last_changed <= report_timestamp),
+    CHECK (report_timestamp <= downloaded_at)
+);
+
+CREATE INDEX IF NOT EXISTS generator_fcas_5m_time_idx
+    ON generator_fcas_5m (interval_start DESC);
+CREATE INDEX IF NOT EXISTS generator_fcas_5m_generator_time_idx
+    ON generator_fcas_5m (generator_id, interval_start DESC);
+
+COMMIT;

--- a/app/migrations/011_fcas_validator_compatibility.sql
+++ b/app/migrations/011_fcas_validator_compatibility.sql
@@ -1,0 +1,95 @@
+-- Replace the migration-010 FCAS validators with PostgreSQL-compatible
+-- cardinality checks while retaining the exact grouped JSONB contract.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION nextday_fcas_service_jsonb_valid(value JSONB)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+IMMUTABLE
+AS $function$
+DECLARE
+    key_count BIGINT;
+    target_type TEXT;
+    status_type TEXT;
+    actual_type TEXT;
+BEGIN
+    IF value IS NULL OR jsonb_typeof(value) <> 'object' THEN
+        RETURN FALSE;
+    END IF;
+    SELECT count(*)
+    INTO key_count
+    FROM jsonb_object_keys(value);
+    IF key_count <> 3
+       OR NOT value ?& ARRAY[
+           'target_mw', 'enablement_status', 'actual_availability_mw'
+       ] THEN
+        RETURN FALSE;
+    END IF;
+
+    target_type := jsonb_typeof(value -> 'target_mw');
+    status_type := jsonb_typeof(value -> 'enablement_status');
+    actual_type := jsonb_typeof(value -> 'actual_availability_mw');
+    IF target_type NOT IN ('null', 'number')
+       OR status_type NOT IN ('null', 'number')
+       OR actual_type NOT IN ('null', 'number') THEN
+        RETURN FALSE;
+    END IF;
+
+    IF target_type = 'number' AND (
+        (value -> 'target_mw') < '0'::jsonb
+        OR (value ->> 'target_mw') IN ('NaN', 'Infinity', '-Infinity')
+    ) THEN
+        RETURN FALSE;
+    END IF;
+    IF actual_type = 'number' AND (
+        (value -> 'actual_availability_mw') < '0'::jsonb
+        OR (value ->> 'actual_availability_mw') IN ('NaN', 'Infinity', '-Infinity')
+    ) THEN
+        RETURN FALSE;
+    END IF;
+    IF status_type = 'number'
+       AND (value ->> 'enablement_status') NOT IN ('0', '1', '2', '3', '4') THEN
+        RETURN FALSE;
+    END IF;
+    RETURN TRUE;
+END
+$function$;
+
+CREATE OR REPLACE FUNCTION nextday_fcas_map_jsonb_valid(value JSONB)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+IMMUTABLE
+AS $function$
+DECLARE
+    key_count BIGINT;
+    service_name TEXT;
+BEGIN
+    IF value IS NULL OR jsonb_typeof(value) <> 'object' THEN
+        RETURN FALSE;
+    END IF;
+    SELECT count(*)
+    INTO key_count
+    FROM jsonb_object_keys(value);
+    IF key_count <> 10
+       OR NOT value ?& ARRAY[
+           'raise_1s', 'lower_1s', 'raise_6s', 'lower_6s',
+           'raise_60s', 'lower_60s', 'raise_5m', 'lower_5m',
+           'raise_reg', 'lower_reg'
+       ] THEN
+        RETURN FALSE;
+    END IF;
+    FOREACH service_name IN ARRAY ARRAY[
+        'raise_1s', 'lower_1s', 'raise_6s', 'lower_6s',
+        'raise_60s', 'lower_60s', 'raise_5m', 'lower_5m',
+        'raise_reg', 'lower_reg'
+    ] LOOP
+        IF NOT nextday_fcas_service_jsonb_valid(value -> service_name) THEN
+            RETURN FALSE;
+        END IF;
+    END LOOP;
+    RETURN TRUE;
+END
+$function$;
+
+COMMIT;


### PR DESCRIPTION
Summary

- Reuse retained AEMO Next Day Dispatch UnitSolution artifacts to project all ten FCAS services alongside SOC.
- Persist one provenance-aware grouped raw/effective record per DUID and interval with deterministic replay, conflict, and precedence handling.
- Add a bounded GET /api/fcas endpoint and dashboard target panel with honest publication state and the explicit target-not-response disclaimer.

Verification

- 47 focused backend tests passed.
- 340 complete backend tests passed.
- 29 frontend tests passed.
- TypeScript typecheck and production build passed.
- Pyright: 0 errors, 0 warnings, 0 informations.
- Migration shell syntax and git diff checks passed.
- Fresh independent final review: PASS with no material findings.

Residual risks

- Migration 010 has static migration coverage but has not been applied to a live PostgreSQL database.
- Production migration, backfill, deployment, and service restart remain separate explicit gates.